### PR TITLE
New link for ledmon issue tracker

### DIFF
--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -206,7 +206,7 @@ static void _ledctl_help(void)
 	       "\t\tdisk_failed=ses_fault\n");
 	printf("Refer to ledctl(8) man page for more detailed description.\n");
 	printf("Bugs should be reported at: " \
-	       "http://sourceforge.net/p/ledmon/bugs \n");
+		"https://github.com/intel/ledmon/issues\n");
 }
 
 /**

--- a/src/ledmon.c
+++ b/src/ledmon.c
@@ -258,8 +258,8 @@ static void _ledmon_help(void)
 	printf
 	    ("--version\t\t\t  Displays version and license information.\n\n");
 	printf("Refer to ledmon(8) man page for more detailed description.\n");
-	printf("Bugs should be reported at: "
-	       "http://sourceforge.net/p/ledmon/bugs \n");
+	printf(
+	"Bugs should be reported at: https://github.com/intel/ledmon/issues\n");
 }
 
 /**


### PR DESCRIPTION
After migrating ledmon to github link for sending bug's is different. Set
ledmon issue tracker link.

Signed-off-by: Michal Zylowski <michal.zylowski@intel.com>