### PR TITLE
Move --list-controllers parameter to ledctl

### DIFF
--- a/doc/ledctl.pod
+++ b/doc/ledctl.pod
@@ -268,6 +268,11 @@ Prints this text out and exits.
 
 Displays version of ledctl and information about the license and exits.
 
+=item B<-L> or B<--list-controllers>
+
+Prints information (system path and type) of all controllers detected by
+ledmon and exits.
+
 =back
 
 =head1 FILES

--- a/doc/ledmon.pod
+++ b/doc/ledmon.pod
@@ -69,11 +69,6 @@ global configuration file and user configuration file has no effect.
 Sets a path to local log file. If this option is specified the global log
 file F</var/log/ledmon.log> is not used.
 
-=item B<-L> or B<--list-controllers>
-
-Prints information (system path and type) of all controllers detected by ledmon
-and exits.
-
 =item B<-t> or B<--interval>=I<seconds>
 
 Sets time interval between scans of sysfs. The value is given in seconds.

--- a/src/cntrl.c
+++ b/src/cntrl.c
@@ -423,22 +423,8 @@ void cntrl_device_fini(struct cntrl_device *device)
 	}
 }
 
-/**
- * @brief Prints given controllers list.
- *
- * This is internal function of monitor service. This function prints the path
- * and type of controller for every controller on given in argument list.
- *
- * @param[in]      ctrl_list           address to first element from
- *                                     controllers list.
- *
- * @return The function does not return a value.
- */
-void cntrl_print_all(struct cntrl_device *ctrl_list)
+void print_cntrl(struct cntrl_device *ctrl_dev)
 {
-	while (ctrl_list != NULL) {
-		printf("%s (%s)\n", ctrl_list->sysfs_path,
-			ctrl_type_str[ctrl_list->cntrl_type]);
-		ctrl_list = list_next(ctrl_list);
-	}
+		printf("%s (%s)\n", ctrl_dev->sysfs_path,
+			ctrl_type_str[ctrl_dev->cntrl_type]);
 }

--- a/src/cntrl.h
+++ b/src/cntrl.h
@@ -110,16 +110,16 @@ struct cntrl_device *cntrl_device_init(const char *path);
 void cntrl_device_fini(struct cntrl_device *device);
 
 /**
- * @brief Prints given controllers list.
+ * @brief Prints given controller to stdout.
  *
- * This is internal function of monitor service. This function prints the path
- * and type of controller for every controller on given in argument list.
+ * This function prints the path and type of controller device given as
+ * argument.
  *
- * @param[in]      ctrl_list           address to first element from
- *                                     controllers list.
+ * @param[in]      ctrl_dev            address to element from a
+ *                                     controller list.
  *
  * @return The function does not return a value.
  */
-void cntrl_print_all(struct cntrl_device *ctrl_list);
+void print_cntrl(struct cntrl_device *ctrl_dev);
 
 #endif				/* _CNTRL_H_INCLUDED_ */

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -102,7 +102,7 @@ static char *ledctl_version = "Intel(R) Enclosure LED Control Application %d.%d\
  * Internal variable of monitor service. It is used to help parse command line
  * short options.
  */
-static char *shortopt = "c:hvl:";
+static char *shortopt = "c:hLvl:";
 
 /**
  * Internal enumeration type. It is used to help parse command line arguments.
@@ -111,7 +111,8 @@ enum longopt {
 	OPT_CONFIG,
 	OPT_HELP,
 	OPT_LOG,
-	OPT_VERSION
+	OPT_VERSION,
+	OPT_LIST_CTRL,
 };
 
 /**
@@ -123,6 +124,7 @@ static struct option longopt[] = {
 	[OPT_HELP]    = {"help", no_argument, NULL, 'h'},
 	[OPT_LOG]     = {"log", required_argument, NULL, 'l'},
 	[OPT_VERSION] = {"version", no_argument, NULL, 'v'},
+	[OPT_LIST_CTRL] = {"list-controllers", no_argument, NULL, 'L'},
 			{NULL, no_argument, NULL, '\0'}
 };
 
@@ -599,6 +601,18 @@ static status_t _cmdline_parse(int argc, char *argv[])
 		case 'l':
 			status = _set_log_path(optarg);
 			break;
+		case 'L':
+			if (sysfs_init() == STATUS_SUCCESS &&
+				sysfs_scan() == STATUS_SUCCESS) {
+				list_for_each(sysfs_get_cntrl_devices(),
+					     print_cntrl);
+				sysfs_reset();
+				exit(EXIT_SUCCESS);
+			} else {
+				log_debug("Unable to scan controllers.");
+				exit(EXIT_FAILURE);
+			}
+		break;
 		case ':':
 		case '?':
 		default:

--- a/src/ledmon.c
+++ b/src/ledmon.c
@@ -128,7 +128,7 @@ static char *ledmon_version = "Intel(R) Enclosure LED Monitor Service %d.%d\n"
  * Internal variable of monitor service. It is used to help parse command line
  * short options.
  */
-static char *shortopt = "t:c:hLvl:";
+static char *shortopt = "t:c:hvl:";
 
 /**
  * Internal enumeration type. It is used to help parse command line arguments.
@@ -146,7 +146,6 @@ enum longopt {
 	OPT_VERSION,
 	OPT_WARNING,
 	OPT_LOG_LEVEL,
-	OPT_LIST_CTRL,
 };
 
 /**
@@ -166,7 +165,6 @@ static struct option longopt[] = {
 	[OPT_VERSION]  = {"version", no_argument, NULL, 'v'},
 	[OPT_WARNING]  = {"warning", no_argument, NULL, '\0'},
 	[OPT_LOG_LEVEL] = {"log-level", required_argument, NULL, '\0'},
-	[OPT_LIST_CTRL] = {"list-controllers", no_argument, NULL, 'L'},
 			 {NULL, no_argument, NULL, '\0'}
 };
 
@@ -439,16 +437,6 @@ static status_t _cmdline_parse(int argc, char *argv[])
 			break;
 		case 'l':
 			status = _set_log_path(optarg);
-			break;
-		case 'L':
-			if (sysfs_init() == STATUS_SUCCESS &&
-				sysfs_scan() == STATUS_SUCCESS) {
-				cntrl_print_all(sysfs_get_cntrl_devices());
-				exit(EXIT_SUCCESS);
-			} else {
-				log_debug("Unable to scan controllers.");
-				exit(EXIT_FAILURE);
-			}
 			break;
 		case 't':
 			status = _set_sleep_interval(optarg);


### PR DESCRIPTION
Ledctl looks like better place for ad-hoc command than ledmon, which is
daemon application. Set --list-controllers parameter as ledctl command.

Signed-off-by: Michal Zylowski <michal.zylowski@intel.com>


Commit also contains some list iteration improvements.
Fixes #9 