### PR TITLE
Add basic ledmon service file for systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,13 @@ install: all
 	$(MAKE) -C src DESTDIR=$(DESTDIR) install
 	$(MAKE) -C doc DESTDIR=$(DESTDIR) install
 
+install-systemd:
+	$(MAKE) -C systemd DESTDIR=$(DESTDIR) install
+
 uninstall:
 	$(MAKE) -C src DESTDIR=$(DESTDIR) uninstall
 	$(MAKE) -C doc DESTDIR=$(DESTDIR) uninstall
+	$(MAKE) -C systemd DESTDIR=$(DESTDIR) uninstall
 
 clean:
 	$(MAKE) -C src clean

--- a/systemd/Makefile
+++ b/systemd/Makefile
@@ -1,0 +1,32 @@
+#
+#  Intel(R) Enclosure LED Utilities
+#  Copyright (C) 2009-2017 Intel Corporation.
+#
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms and conditions of the GNU General Public License,
+#  version 2, as published by the Free Software Foundation.
+#
+#  This program is distributed in the hope it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU General Public License along with
+#  this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# Installation directory prefix.
+DESTDIR?=
+
+# Installation directory of ledmon systemd service unit.
+SYSTEMD_SERVICE_INSTDIR=$(DESTDIR)/etc/systemd/system
+
+default:
+
+uninstall:
+	rm -f $(SYSTEMD_SERVICE_INSTDIR)/ledmon.service
+
+install:
+	install -D ./ledmon.service $(SYSTEMD_SERVICE_INSTDIR)/ledmon.service
+

--- a/systemd/ledmon.service
+++ b/systemd/ledmon.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Enclosure LED Utilities
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=forking
+User=root
+ExecStart=/usr/sbin/ledmon
+Restart=on-failure


### PR DESCRIPTION
This is a simple system service that I have been using on a few CentOS 7 servers. I'm creating this pull request in the hope that it might be useful to others, but if it's not the right place for a systemd service feel free to delete it.