### PR TITLE
2018-08-13: bunch of various small fixes

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,12 +1,12 @@
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-                       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
@@ -15,7 +15,7 @@ software--to make sure the software is free for all its users.  This
 General Public License applies to most of the Free Software
 Foundation's software and to any other program whose authors commit to
 using it.  (Some other Free Software Foundation software is covered by
-the GNU Library General Public License instead.)  You can apply it to
+the GNU Lesser General Public License instead.)  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
@@ -55,8 +55,8 @@ patent must be licensed for everyone's free use or not licensed at all.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
-
-		    GNU GENERAL PUBLIC LICENSE
+
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License applies to any program or other work which contains
@@ -110,7 +110,7 @@ above, provided that you also meet all of these conditions:
     License.  (Exception: if the Program itself is interactive but
     does not normally print such an announcement, your work based on
     the Program is not required to print an announcement.)
-
+
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
 and can be reasonably considered independent and separate works in
@@ -168,7 +168,7 @@ access to copy from a designated place, then offering equivalent
 access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
-
+
   4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
@@ -225,7 +225,7 @@ impose that choice.
 
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-
+
   8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
@@ -255,7 +255,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -277,9 +277,9 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
-
-	    How to Apply These Terms to Your New Programs
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
@@ -291,7 +291,7 @@ convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) 19yy  <name of author>
+    Copyright (C) <year>  <name of author>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -303,17 +303,16 @@ the "copyright" line and a pointer to where the full notice is found.
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 Also add information on how to contact you by electronic and paper mail.
 
 If the program is interactive, make it output a short notice like this
 when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) 19yy name of author
+    Gnomovision version 69, Copyright (C) year name of author
     Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -336,5 +335,5 @@ necessary.  Here is a sample; alter the names:
 This General Public License does not permit incorporating your program into
 proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Library General
+library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,6 @@ all: ledmon ledctl man
 install: all
 	$(MAKE) -C src DESTDIR=$(DESTDIR) install
 	$(MAKE) -C doc DESTDIR=$(DESTDIR) install
-
-install-systemd:
 	$(MAKE) -C systemd DESTDIR=$(DESTDIR) install
 
 uninstall:

--- a/doc/ledmon.pod
+++ b/doc/ledmon.pod
@@ -81,6 +81,12 @@ everything. The levels are given in order. If user specifies more then one
 verbose option the last option comes into effect. The default level is
 'warning'. Verbose level also can be set by B<--log-level>=I<level>.
 
+=item B<--foreground>
+
+Run process foreground instead of a daemon. This option is useful in
+systemd service file. Another use case of this option is debugging with
+elevated B<--log-level>=I<level>.
+
 =item B<-h> or B<--help>
 
 Prints this text out and exits.

--- a/src/ahci.c
+++ b/src/ahci.c
@@ -34,10 +34,10 @@
 #include "utils.h"
 
 /**
- * Time interval in u-seconds to wait before enclosure management message is being
- * sent to AHCI controller.
+ * Time interval in nano seconds to wait before enclosure management message
+ * is being sent to AHCI controller.
  */
-#define EM_MSG_WAIT       1500
+#define EM_MSG_WAIT       1500000	/* 0.0015 seconds */
 
 /**
  * This array maps IBPI pattern to value recognized by AHCI driver. The driver
@@ -73,6 +73,10 @@ int ahci_sgpio_write(struct block_device *device, enum ibpi_pattern ibpi)
 	char temp[WRITE_BUFFER_SIZE];
 	char path[PATH_MAX];
 	char *sysfs_path = device->cntrl_path;
+	const struct timespec waittime = {
+		.tv_sec = 0,
+		.tv_nsec = EM_MSG_WAIT
+	};
 
 	/* write only if state has changed */
 	if (ibpi == device->ibpi_prev)
@@ -88,7 +92,7 @@ int ahci_sgpio_write(struct block_device *device, enum ibpi_pattern ibpi)
 	str_cpy(path, sysfs_path, PATH_MAX);
 	str_cat(path, "/em_message", PATH_MAX);
 
-	usleep(EM_MSG_WAIT);
+	nanosleep(&waittime, NULL);
 	return buf_write(path, temp) > 0;
 }
 

--- a/src/ahci.c
+++ b/src/ahci.c
@@ -89,8 +89,7 @@ int ahci_sgpio_write(struct block_device *device, enum ibpi_pattern ibpi)
 
 	sprintf(temp, "%u", ibpi2sgpio[ibpi]);
 
-	str_cpy(path, sysfs_path, PATH_MAX);
-	str_cat(path, "/em_message", PATH_MAX);
+	snprintf(path, sizeof(path), "%s/%s", sysfs_path, "em_message");
 
 	nanosleep(&waittime, NULL);
 	return buf_write(path, temp) > 0;
@@ -112,10 +111,7 @@ char *ahci_get_port_path(const char *path)
 	s = strrchr(tmp, PATH_DELIM);
 	if (s == NULL)
 		return NULL;
-
-	str_cpy(buf, s, BUFFER_MAX);
-	str_cat(tmp, "/scsi_host", PATH_MAX);
-	str_cat(tmp, buf, PATH_MAX);
+	snprintf(tmp, sizeof(tmp), "%s/%s%s", s, "scsi_host", buf);
 
 	return str_dup(tmp);
 }

--- a/src/ahci.c
+++ b/src/ahci.c
@@ -105,7 +105,7 @@ char *ahci_get_port_path(const char *path)
 	if (p == NULL)
 		return NULL;
 	*p = '\0';
-	s = rindex(tmp, PATH_DELIM);
+	s = strrchr(tmp, PATH_DELIM);
 	if (s == NULL)
 		return NULL;
 

--- a/src/block.c
+++ b/src/block.c
@@ -240,7 +240,7 @@ struct block_device *block_device_init(const struct list *cntrl_list, const char
 			struct _host_type *hosts = cntrl ? cntrl->hosts : NULL;
 
 			device->cntrl = cntrl;
-			device->sysfs_path = strdup(link);
+			device->sysfs_path = str_dup(link);
 			device->cntrl_path = host;
 			device->ibpi = IBPI_PATTERN_UNKNOWN;
 			device->ibpi_prev = IBPI_PATTERN_NONE;
@@ -306,8 +306,8 @@ struct block_device *block_device_duplicate(struct block_device *block)
 	if (block) {
 		result = calloc(1, sizeof(*result));
 		if (result) {
-			result->sysfs_path = strdup(block->sysfs_path);
-			result->cntrl_path = strdup(block->cntrl_path);
+			result->sysfs_path = str_dup(block->sysfs_path);
+			result->cntrl_path = str_dup(block->cntrl_path);
 			if (block->ibpi != IBPI_PATTERN_UNKNOWN)
 				result->ibpi = block->ibpi;
 			else

--- a/src/cntrl.c
+++ b/src/cntrl.c
@@ -72,8 +72,7 @@ static int _is_ahci_cntrl(const char *path)
 {
 	char temp[PATH_MAX], link[PATH_MAX], *t;
 
-	str_cpy(temp, path, PATH_MAX);
-	str_cat(temp, "/driver", PATH_MAX);
+	snprintf(temp, sizeof(temp), "%s/%s", path, "driver");
 
 	if (realpath(temp, link) == NULL)
 		return 0;

--- a/src/cntrl.c
+++ b/src/cntrl.c
@@ -369,7 +369,7 @@ struct cntrl_device *cntrl_device_init(const char *path)
 					device->hosts = NULL;
 				}
 				device->cntrl_type = type;
-				device->sysfs_path = strdup(path);
+				device->sysfs_path = str_dup(path);
 			}
 		} else {
 			log_error

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -72,7 +72,7 @@ static void parse_list(struct list *list, char *s)
 		if (sep)
 			*sep = '\0';
 
-		list_append(list, strdup(s));
+		list_append(list, str_dup(s));
 
 		if (sep)
 			s = sep + 1;

--- a/src/dellssd.c
+++ b/src/dellssd.c
@@ -232,7 +232,7 @@ static int ipmi_setled(int b, int d, int f, int state)
 
 char *dellssd_get_path(const char *cntrl_path)
 {
-	return strdup(cntrl_path);
+	return str_dup(cntrl_path);
 }
 
 int dellssd_write(struct block_device *device, enum ibpi_pattern ibpi)

--- a/src/enclosure.c
+++ b/src/enclosure.c
@@ -42,12 +42,14 @@
  *
  * @return SAS address of an enclosure if successful, otherwise 0.
  */
+#define sas_device "/sas_device"
 static uint64_t _get_sas_address(const char *path)
 {
-	char tmp[PATH_MAX], buf[BUFFER_MAX];
+	char tmp[strlen(path) + 1];
+	char buf[sizeof(tmp) + sizeof(sas_device)];
 	char *p, *s;
 
-	str_cpy(tmp, path, PATH_MAX);
+	str_cpy(tmp, path, sizeof(tmp));
 	p = strstr(tmp, "/expander");
 	if (p == NULL)
 		return 0;
@@ -55,12 +57,8 @@ static uint64_t _get_sas_address(const char *path)
 	if (s == NULL)
 		return 0;
 	*s = '\0';
-
-	str_cpy(buf, p, s - p + 1);
-	str_cat(tmp, "/sas_device", PATH_MAX);
-	str_cat(tmp, buf, PATH_MAX);
-
-	return get_uint64(tmp, 0, "sas_address");
+	snprintf(buf, sizeof(buf), "%s%s%s", tmp, sas_device, p);
+	return get_uint64(buf, 0, "sas_address");
 }
 
 #define SCSI_GEN "device/scsi_generic"

--- a/src/ledmon.c
+++ b/src/ledmon.c
@@ -251,7 +251,7 @@ static status_t _set_config_path(char **conf_path, const char *path)
 
 	if (*conf_path)
 		free(*conf_path);
-	*conf_path = strdup(path);
+	*conf_path = str_dup(path);
 
 	return STATUS_SUCCESS;
 }
@@ -646,7 +646,7 @@ static void _add_block(struct block_device *block)
 			log_info("NAME CHANGED %s to %s",
 				 temp->sysfs_path, block->sysfs_path);
 			free(temp->sysfs_path);
-			temp->sysfs_path = strdup(block->sysfs_path);
+			temp->sysfs_path = str_dup(block->sysfs_path);
 		}
 	} else {
 		/* Device not found, it's a new one! */

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -44,9 +44,7 @@ status_t pidfile_create(const char *name)
 	char buf[PATH_MAX];
 	int fd, count;
 
-	str_cpy(buf, "/var/run/", PATH_MAX);
-	str_cat(buf, name, PATH_MAX);
-	str_cat(buf, ".pid", PATH_MAX);
+	snprintf(buf, sizeof(buf), "%s/%s%s", "/var/run/", name, ".pid");
 
 	fd = open(buf, O_WRONLY | O_CREAT, 0640);
 	if (fd < 0)
@@ -67,10 +65,7 @@ int pidfile_remove(const char *name)
 {
 	char buf[PATH_MAX];
 
-	str_cpy(buf, "/var/run/", PATH_MAX);
-	str_cat(buf, name, PATH_MAX);
-	str_cat(buf, ".pid", PATH_MAX);
-
+	snprintf(buf, sizeof(buf), "%s/%s%s", "/var/run/", name, ".pid");
 	return unlink(buf);
 }
 
@@ -96,9 +91,7 @@ status_t pidfile_check(const char *name, pid_t *pid)
 	char path[PATH_MAX], *p;
 	pid_t tp;
 
-	str_cpy(path, "/var/run/", PATH_MAX);
-	str_cat(path, name, PATH_MAX);
-	str_cat(path, ".pid", PATH_MAX);
+	snprintf(path, sizeof(path), "%s/%s%s", "/var/run/", name, ".pid");
 
 	p = buf_read(path);
 	if (p == NULL)

--- a/src/raid.c
+++ b/src/raid.c
@@ -137,7 +137,7 @@ struct raid_device *raid_device_init(const char *path, unsigned int device_num,
 	    (type == DEVICE_TYPE_CONTAINER && state > RAID_STATE_CLEAR)) {
 		device = malloc(sizeof(struct raid_device));
 		if (device) {
-			device->sysfs_path = strdup(path);
+			device->sysfs_path = str_dup(path);
 			device->device_num = device_num;
 			device->sync_action = _get_sync_action(path);
 			device->array_state = state;
@@ -178,7 +178,7 @@ struct raid_device *raid_device_duplicate(struct raid_device *device)
 		new_device = malloc(sizeof(struct raid_device));
 		if (new_device) {
 			*new_device = *device;
-			new_device->sysfs_path = strdup(device->sysfs_path);
+			new_device->sysfs_path = str_dup(device->sysfs_path);
 		}
 	}
 	return new_device;

--- a/src/scsi.c
+++ b/src/scsi.c
@@ -607,8 +607,7 @@ static int _slot_match(const char *slot_path, const char *device_path)
 {
 	char temp[PATH_MAX], link[PATH_MAX];
 
-	str_cpy(temp, slot_path, PATH_MAX);
-	str_cat(temp, "/device", PATH_MAX);
+	snprintf(temp, sizeof(temp), "%s/%s", slot_path, "device");
 
 	if (realpath(temp, link) == NULL)
 		return 0;

--- a/src/scsi.c
+++ b/src/scsi.c
@@ -626,7 +626,7 @@ static char *_slot_find(const char *enclo_path, const char *device_path)
 	if (scan_dir(enclo_path, &dir) == 0) {
 		list_for_each(&dir, temp) {
 			if (_slot_match(temp, device_path)) {
-				result = strdup(temp);
+				result = str_dup(temp);
 				break;
 			}
 		}

--- a/src/slave.c
+++ b/src/slave.c
@@ -96,8 +96,7 @@ static struct block_device *_get_block(const char *path, struct list *block_list
 	char link[PATH_MAX];
 	struct block_device *device;
 
-	str_cpy(temp, path, PATH_MAX);
-	str_cat(temp, "/block", PATH_MAX);
+	snprintf(temp, sizeof(temp), "%s/%s", path, "block");
 
 	if (!realpath(temp, link))
 		return NULL;

--- a/src/smp.c
+++ b/src/smp.c
@@ -582,7 +582,7 @@ int cntrl_init_smp(const char *path, struct cntrl_device *cntrl)
 
 	/* Other case - just init controller. */
 	if (path && strstr(path, "port-")) {
-		path2 = strdup(path);
+		path2 = str_dup(path);
 		if (!path2)
 			return port;
 

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -156,8 +156,7 @@ static void _get_id(const char *path, struct device_id *d_id)
 {
 	char temp[PATH_MAX];
 
-	str_cpy(temp, path, PATH_MAX);
-	str_cat(temp, "/dev", PATH_MAX);
+	snprintf(temp, sizeof(temp), "%s/%s", path, "dev");
 	get_id(temp, d_id);
 }
 
@@ -259,8 +258,7 @@ static void _link_raid_device(struct raid_device *device, enum device_type type)
 	char temp[PATH_MAX];
 	struct list dir;
 
-	str_cpy(temp, device->sysfs_path, PATH_MAX);
-	str_cat(temp, "/md", PATH_MAX - 1);
+	snprintf(temp, sizeof(temp), "%s/%s", device->sysfs_path, "md");
 
 	if (scan_dir(temp, &dir) == 0) {
 		const char *dir_path;
@@ -663,10 +661,8 @@ int sysfs_check_driver(const char *path, const char *driver)
 	char driver_path[PATH_MAX];
 	char *link;
 	int found = 0;
-	str_cpy(buf, path, PATH_MAX);
-	str_cat(buf, "/driver", PATH_MAX - 1);
-	snprintf(driver_path, PATH_MAX - 1, "/%s", driver);
 
+	snprintf(buf, sizeof(buf), "%s/%s/%s", path, "driver", driver);
 	link = realpath(buf, NULL);
 	if (link && strstr(link, driver_path))
 		found = 1;

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -179,7 +179,7 @@ static void _slave_vol_add(const char *path, struct raid_device *raid)
 {
 	struct slave_device *device;
 
-	char *t = rindex(path, '/');
+	char *t = strrchr(path, '/');
 	if (strncmp(t + 1, "dev-", 4) == 0) {
 		device = slave_device_init(path, &sysfs_block_list);
 		if (device) {
@@ -240,7 +240,7 @@ static void _slave_cnt_add(const char *path, struct raid_device *raid)
 {
 	struct slave_device *device;
 
-	char *t = rindex(path, '/');
+	char *t = strrchr(path, '/');
 	if (strncmp(t + 1, "dev-", 4) == 0) {
 		device = slave_device_init(path, &sysfs_block_list);
 		if (device) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -288,7 +288,7 @@ int log_open(const char *path)
 {
 	if (s_log)
 		log_close();
-	char *t = rindex(path, PATH_DELIM);
+	char *t = strrchr(path, PATH_DELIM);
 	if (t)
 		*t = '\0';
 	int status = _mkdir(path);
@@ -419,7 +419,7 @@ void set_invocation_name(char *invocation_name)
 	(void)invocation_name;
 	progname = program_invocation_short_name;
 #else
-	char *t = rindex(invocation_name, PATH_DELIM);
+	char *t = strrchr(invocation_name, PATH_DELIM);
 	if (t)
 		progname = t + 1;
 	else

--- a/src/utils.c
+++ b/src/utils.c
@@ -587,6 +587,7 @@ struct option longopt_all[] = {
 	[OPT_LOG_LEVEL]    = {"log-level", required_argument, NULL, '\0'},
 	[OPT_LIST_CTRL]    = {"list-controllers", no_argument, NULL, 'L'},
 	[OPT_LISTED_ONLY]  = {"listed-only", no_argument, NULL, 'x'},
+	[OPT_FOREGROUND]   = {"foreground", no_argument, NULL, FOREGROUND_OPT_VALUE},
 	[OPT_NULL_ELEMENT] = {NULL, no_argument, NULL, '\0'}
 };
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -440,9 +440,16 @@ char *str_cpy(char *dest, const char *src, size_t size)
  */
 char *str_dup(const char *src)
 {
-	if (src && (strlen(src) > 0))
-		return strdup(src);
-	return NULL;
+	char *ret;
+
+        if (!src)
+                return NULL;
+        ret = strdup(src);
+        if (!ret) {
+		log_error("Cannot duplicate string");
+		exit(EXIT_FAILURE);
+	}
+	return ret;
 }
 
 /**
@@ -458,7 +465,7 @@ char *str_cat(char *dest, const char *src, size_t size)
 
 char *get_path_hostN(const char *path)
 {
-	char *c = NULL, *s = NULL, *p = strdup(path);
+	char *c = NULL, *s = NULL, *p = str_dup(path);
 	if (!p)
 		return NULL;
 	c = strstr(p, "host");
@@ -468,7 +475,7 @@ char *get_path_hostN(const char *path)
 	if (!s)
 		goto end;
 	*s = 0;
-	s = strdup(c);
+	s = str_dup(c);
  end:
 	free(p);
 	return s;
@@ -477,7 +484,7 @@ char *get_path_hostN(const char *path)
 char *get_path_component_rev(const char *path, int index)
 {
 	int i;
-	char *c = NULL, *p = strdup(path);
+	char *c = NULL, *p = str_dup(path);
 	char *result = NULL;
 	for (i = 0; i <= index; i++) {
 		if (c)
@@ -485,7 +492,7 @@ char *get_path_component_rev(const char *path, int index)
 		c = strrchr(p, '/');
 	}
 	if (c)
-		result = strdup(c + 1);
+		result = str_dup(c + 1);
 	free(p);
 	return result;
 }
@@ -502,7 +509,7 @@ char *truncate_path_component_rev(const char *path, int index)
 			*c = '\0';
 		c = strrchr(p, '/');
 	}
-	c = strdup(p);
+	c = str_dup(p);
 	free(p);
 	return c;
 }
@@ -570,7 +577,7 @@ status_t set_log_path(const char *path)
 
 	if (conf.log_path)
 		free(conf.log_path);
-	conf.log_path = strdup(temp);
+	conf.log_path = str_dup(temp);
 
 	return STATUS_SUCCESS;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -72,10 +72,7 @@ char *get_text(const char *path, const char *name)
 {
 	char temp[PATH_MAX];
 
-	str_cpy(temp, path, PATH_MAX);
-	str_cat(temp, PATH_DELIM_STR, PATH_MAX);
-	str_cat(temp, name, PATH_MAX);
-
+	snprintf(temp, sizeof(temp), "%s/%s", path, name);
 	return buf_read(temp);
 }
 
@@ -450,17 +447,6 @@ char *str_dup(const char *src)
 		exit(EXIT_FAILURE);
 	}
 	return ret;
-}
-
-/**
- */
-char *str_cat(char *dest, const char *src, size_t size)
-{
-	int t = strlen(dest);
-	strncat(dest, src, size - t);
-	if (t + strlen(src) >= size)
-		dest[size - 1] = '\0';
-	return dest;
 }
 
 char *get_path_hostN(const char *path)

--- a/src/utils.h
+++ b/src/utils.h
@@ -21,6 +21,7 @@
 #define _UTILS_H_INCLUDED_
 
 #include <getopt.h>
+#include <limits.h>
 #include "stdlib.h"
 #include "stdint.h"
 #include "list.h"
@@ -360,7 +361,12 @@ enum opt {
 	OPT_LOG_LEVEL,
 	OPT_LIST_CTRL,
 	OPT_LISTED_ONLY,
+	OPT_FOREGROUND,
 	OPT_NULL_ELEMENT
+};
+
+enum {
+	FOREGROUND_OPT_VALUE = CHAR_MAX + 1,
 };
 
 extern struct option longopt_all[];

--- a/src/utils.h
+++ b/src/utils.h
@@ -316,25 +316,6 @@ char *str_cpy(char *dest, const char *src, size_t size);
 char *str_dup(const char *src);
 
 /**
- * @brief Concatenates text buffers.
- *
- * This function appends source buffer to destination buffer. It is similar to
- * strncat() standard C function except it always returns null-terminated
- * buffer. Second difference is that function calculates itself the amount
- * of free space in destination buffer. If source does not fit in dest
- * then as many bytes are copied as can be fit in destination buffer minus 1
- * for null-character. Otherwise the source is copied to destination
- * including null-character.
- *
- * @param[in,out]  dest            Pointer to destination buffer.
- * @param[in]      src             Pointer to source buffer.
- * @param[in]      size            Capacity of destination buffer.
- *
- * @return Pointer to destination buffer even if function failed.
- */
-char *str_cat(char *dest, const char *src, size_t size);
-
-/**
  */
 char *truncate_path_component_rev(const char *path, int index);
 

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -88,7 +88,8 @@ static int check_slot_module(const char *slot_path)
 	snprintf(module_path, PATH_MAX, "%s/module", slot_path);
 	if (scan_dir(module_path, &dir) == 0) {
 		list_erase(&dir);
-		realpath(module_path, real_module_path);
+		if (realpath(module_path, real_module_path) == NULL)
+			return -1;
 		if (strcmp(real_module_path, SYSFS_PCIEHP) != 0)
 			__set_errno_and_return(EINVAL);
 	} else {

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -42,9 +42,7 @@
 static char *get_slot_from_syspath(char *path)
 {
 	char *cur, *ret = NULL;
-	char *temp_path = strdup(path);
-	if (!temp_path)
-		return NULL;
+	char *temp_path = str_dup(path);
 
 	cur = strtok(temp_path, "/");
 	while (cur != NULL) {
@@ -57,7 +55,7 @@ static char *get_slot_from_syspath(char *path)
 
 	cur = strtok(cur, ".");
 	if (cur)
-		ret = strdup(cur);
+		ret = str_dup(cur);
 	free(temp_path);
 
 	return ret;
@@ -165,5 +163,5 @@ int vmdssd_write(struct block_device *device, enum ibpi_pattern ibpi)
 
 char *vmdssd_get_path(const char *cntrl_path)
 {
-	return strdup(cntrl_path);
+	return str_dup(cntrl_path);
 }

--- a/systemd/Makefile
+++ b/systemd/Makefile
@@ -16,11 +16,13 @@
 #  51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-# Installation directory prefix.
+# Comment out, and uncomment empty if you do not want pkg-config path.
+SYSTEMD_SERVICE_INSTDIR=$(shell pkg-config --variable=systemdsystemunitdir systemd)
+#SYSTEMD_SERVICE_INSTDIR=
+ifeq ($(SYSTEMD_SERVICE_INSTDIR),)
 DESTDIR?=
-
-# Installation directory of ledmon systemd service unit.
 SYSTEMD_SERVICE_INSTDIR=$(DESTDIR)/etc/systemd/system
+endif
 
 default:
 

--- a/systemd/ledmon.service
+++ b/systemd/ledmon.service
@@ -5,7 +5,7 @@ Description=Enclosure LED Utilities
 WantedBy=multi-user.target
 
 [Service]
-Type=forking
+Type=simple
 User=root
-ExecStart=/usr/sbin/ledmon
+ExecStart=/usr/sbin/ledmon --foreground
 Restart=on-failure


### PR DESCRIPTION
There is not much common idea with these changes. Some are about avoiding deprecated functions, other to be more robust, and then there is the correction to FSF license file. As in my earlier pull request all changes are as small as could make them, if squashes are needed that's fine.

I don't think these of the changes is particularly controversial, other than maybe the pkg-config update. There really isn't great way to do that. Notice that adding install prefix to systemd unit dir would be incorrect, although that will cause 'make install' to try overwrite system file.  But even with that shortcoming it's better to use pkg-config directory than /etc/systemd/system/ that has it's own problems. See commit message for details.