### PR TITLE
Fix for parallel compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ ledctl:
 man:
 	$(MAKE) -C doc BUILD_LABEL="$(BUILD_LABEL)" all
 
-all: ledmon ledctl man
+all:
+	$(MAKE) -C src BUILD_LABEL="$(BUILD_LABEL)" all
+	$(MAKE) -C doc BUILD_LABEL="$(BUILD_LABEL)" all
 
 install: all
 	$(MAKE) -C src DESTDIR=$(DESTDIR) install


### PR DESCRIPTION
Parallel compilation of 'ledmon' and 'ledctl' targets from src/Makefile
can cause race between gcc threads and lead to corruption of object files.
To fix this, object files should be built first, and then ledmon and
ledctl binaries.

Fixes #26

Signed-off-by: Mariusz Dabrowski <mariusz.dabrowski@intel.com>