### PR TITLE
dellssd: do not try to send IPMI command for every PCI device

### DIFF
--- a/src/cntrl.c
+++ b/src/cntrl.c
@@ -89,16 +89,17 @@ extern int get_dell_server_type(void);
 static int _is_dellssd_cntrl(const char *path)
 {
 	uint64_t vdr, dev, svdr, cls;
-	int gen;
+	int gen = 0;
 
-	gen = get_dell_server_type();
 	vdr = get_uint64(path, 0, "vendor");
 	dev = get_uint64(path, 0, "device");
 	cls = get_uint64(path, 0, "class");
 	svdr = get_uint64(path, 0, "subsystem_vendor");
+	if (cls == 0x10802)
+		gen = get_dell_server_type();
 
 	return ((vdr == 0x1344L && dev == 0x5150L) || /* micron ssd */
-		(gen != 0 && cls == 0x10802) ||      /* Dell Server+NVME */
+		(gen != 0) ||			      /* Dell Server+NVME */
 	        (svdr == 0x1028 && cls == 0x10802));  /* nvmhci ssd */
 }
 

--- a/src/dellssd.c
+++ b/src/dellssd.c
@@ -216,7 +216,7 @@ int get_dell_server_type()
 	rc = ipmicmd(BMC_SA, 0, APP_NETFN, APP_GET_SYSTEM_INFO, 4, data,
 		     20, &rlen, rdata);
 	if (rc) {
-		log_error("Unable to issue IPMI command GetSystemInfo\n");
+		log_debug("Unable to issue IPMI command GetSystemInfo\n");
 		return 0;
 	}
 	switch (rdata[10]) {


### PR DESCRIPTION
get_dell_server_type should be called only for NVMe PCI devices.
Additionally, message informing about ipmicmd error shouldn't be logged
with error because it doesn't have to be real error, e. g. platform doesn't
have IPMI or BMC does not support DELL IPMI command.

Signed-off-by: Mariusz Dabrowski <mariusz.dabrowski@intel.com>

@jharg can you take a look at this change?
Fixes #31 