### PR TITLE
use proper format string with syslog()

### DIFF
--- a/src/ledmon.c
+++ b/src/ledmon.c
@@ -202,7 +202,7 @@ static void _ledmon_status(int status, void *arg)
 	if (get_log_fd() >= 0)
 		_log(log_level, message);
 	else
-		syslog(log_level_infos[log_level].priority, message);
+		syslog(log_level_infos[log_level].priority, "%s", message);
 }
 
 /**


### PR DESCRIPTION
Fixes the following:

$ CFLAGS="-Wall -Werror=format-security" make
...
ledmon.c: In function ‘_ledmon_status’:
ledmon.c:205:47: error: format not a string literal and no format arguments [-Werror=format-security]
   syslog(log_level_infos[log_level].priority, message);
                                               ^~~~~~~