### PR TITLE
ledmon: change in build process to support older automake versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_SUBST([PACKAGE_DATE], "April 2019")
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 # Checks for programs.
+AM_PROG_CC_C_O
 AC_PROG_CC_C99
 AC_PROG_INSTALL
 AC_CONFIG_HEADERS([config_ac.h])


### PR DESCRIPTION
This patch removes build errors when building ledmon using automake
version older than 1.14.

Signed-off-by: Krzysztof Smolinski <krzysztof.smolinski@intel.com>