### PR TITLE
AMD: Validate libahci enclosure management messages are enabled.

### DIFF
--- a/src/amd_sgpio.c
+++ b/src/amd_sgpio.c
@@ -819,6 +819,17 @@ int amd_sgpio_em_enabled(const char *path)
 	uint32_t caps;
 	char em_path[PATH_MAX];
 
+	/* Check that libahci module was loaded with ahci_em_messages=1 */
+	p = get_text("/sys/module/libahci/parameters", "ahci_em_messages");
+	if (!p || (p && *p == 'N')) {
+		log_info("Kernel libahci module enclosure management messaging not enabled.\n");
+		if (p)
+			free(p);
+		return 0;
+	}
+
+	free(p);
+
 	/* Find base path for enclosure management */
 	found = _find_file_path(path, "em_buffer", em_path, PATH_MAX);
 	if (!found) {


### PR DESCRIPTION
The libahci kernel module takes an optional parameter,
libahci.ahci_em_messages, that controls enclosure management messages
enablement. This has to be enabled to use SGPIO registers on AMD systems.

Update enclosure management enablement validation for AMD systems to
verify messaging is enabled.

Signed-off-by: Nathan Fontenot <nathan.fontenot@amd.com>