### PR TITLE
ledmon: handling return codes returned by ftruncate and dup functions

### DIFF
--- a/src/amd_sgpio.c
+++ b/src/amd_sgpio.c
@@ -248,8 +248,12 @@ static int _open_and_map_cache(void)
 	flock(cache_fd, LOCK_EX);
 
 	fstat(cache_fd, &sbuf);
-	if (sbuf.st_size == 0)
-		ftruncate(cache_fd, CACHE_SZ);
+	if (sbuf.st_size == 0) {
+		if (ftruncate(cache_fd, CACHE_SZ) != 0) {
+			log_error("Couldn't truncate SGPIO cache: %s", strerror(errno));
+			return -1;
+		}
+	}
 
 	sgpio_cache = mmap(NULL, CACHE_SZ, PROT_READ | PROT_WRITE,
 			   MAP_SHARED, cache_fd, 0);

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -261,7 +261,10 @@ int ledmon_write_shared_conf(void)
 	if (fd == -1)
 		return STATUS_FILE_OPEN_ERROR;
 
-	ftruncate(fd, sizeof(buf));
+	if (ftruncate(fd, sizeof(buf)) != 0) {
+		close(fd);
+		return STATUS_FILE_WRITE_ERROR;
+	}
 
 	shared_mem_ptr = mmap(NULL, sizeof(buf), PROT_WRITE, MAP_SHARED, fd, 0);
 	if (shared_mem_ptr == MAP_FAILED) {

--- a/src/ledmon.c
+++ b/src/ledmon.c
@@ -913,9 +913,8 @@ int main(int argc, char *argv[])
 		_close_parent_fds();
 
 		int t = open("/dev/null", O_RDWR);
-
-		dup(t);
-		dup(t);
+		UNUSED(dup(t));
+		UNUSED(dup(t));
 	}
 
 	umask(027);

--- a/src/utils.h
+++ b/src/utils.h
@@ -30,6 +30,12 @@
 #include "ibpi.h"
 
 /**
+ * Value is intentionally unused.
+ * Macro to prevent compiler from raising unused result warning.
+ */
+#define UNUSED(x) do { if (x); } while (0)
+
+/**
  * Maximum number of bytes in temporary buffer. It is used for local variables.
  */
 #define BUFFER_MAX          128


### PR DESCRIPTION
Added checks whether ftruncate function calls succeed. Values returned
by some dup function calls is intentionally unused. This patch removes
build errors when building ledmon on Ubuntu distribution.

Signed-off-by: Krzysztof Smolinski <krzysztof.smolinski@intel.com>