### PR TITLE
Don't build with -Werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,6 @@ AX_AM_CFLAGS_ADD([-Werror=format-truncation=1])
 AX_AM_CFLAGS_ADD([-Werror=shift-negative-value])
 AX_AM_CFLAGS_ADD([-Werror=alloca])
 AX_AM_CFLAGS_ADD([-Werror=missing-field-initializers])
-AX_AM_CFLAGS_ADD([-Werror])
 AX_AM_CFLAGS_ADD([-Werror=format-signedness])
 
 AC_SUBST([AM_CFLAGS])


### PR DESCRIPTION
New compiler versions might output new warnings by default
(see #47 for an example), which makes -Werror problematic
for distributions.

The more specific -Werror= settings are usually not a problem.

The warnings are still shown, but they will no longer break
the build.

Signed-off-by: Adrian Bunk <bunk@debian.org>