### PR TITLE
ledmon: paths in systemd service file are generated

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,5 +21,5 @@ if SYSTEMD_CONDITION
 endif
 
 SUBDIRS = doc src $(OPTIONAL_SUBDIR)
-EXTRA_DIST = config/config.h systemd/ledmon.service
+EXTRA_DIST = config/config.h systemd/ledmon.service.in
 dist_doc_DATA = README

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -18,6 +18,12 @@
 
 # Installation directory of ledmon systemd service unit.
 systemddir = @SYSTEMD_PATH@
+SED = sed
+
+CLEANFILES = ledmon.service ledmon.service.tmp
 
 systemd_DATA = ledmon.service
 
+ledmon.service : ledmon.service.in
+	$(SED) -e 's|@sbindir[@]|$(sbindir)|g' < $< > $@.tmp
+	mv $@.tmp $@

--- a/systemd/ledmon.service.in
+++ b/systemd/ledmon.service.in
@@ -7,5 +7,5 @@ WantedBy=multi-user.target
 [Service]
 Type=simple
 User=root
-ExecStart=/usr/sbin/ledmon --foreground
+ExecStart=@sbindir@/ledmon --foreground
 Restart=on-failure


### PR DESCRIPTION
Ledmon service file contained hardcoded path to ledmon executable.
This patch places correct installation path of ledmon in systemd
service file.

Signed-off-by: Krzysztof Smolinski <krzysztof.smolinski@intel.com>