### PR TITLE
Update ibpi pattern for block devices added by udev with previous unk…

### DIFF
--- a/src/udev.c
+++ b/src/udev.c
@@ -191,7 +191,8 @@ int handle_udev_event(struct list *ledmon_block_list)
 		if (act == UDEV_ACTION_ADD) {
 			log_debug("ADDED %s", block->sysfs_path);
 			if (block->ibpi == IBPI_PATTERN_FAILED_DRIVE ||
-				block->ibpi == IBPI_PATTERN_REMOVED)
+				block->ibpi == IBPI_PATTERN_REMOVED ||
+				block->ibpi == IBPI_PATTERN_UNKNOWN)
 				block->ibpi = IBPI_PATTERN_ADDED;
 		} else if (act == UDEV_ACTION_REMOVE) {
 			log_debug("REMOVED %s", block->sysfs_path);


### PR DESCRIPTION
…nown ibpi pattern

Update udev events handler in ledmon so block devices that were just added,
and which previous IBPI pattern is unknown, are correctly processed.
IBPI pattern for them could be set to Unknown in a case when several devices were
removed/added simultaneously. In such case udev handler processes first ADD
event and for the rest of the block devices, IBPI became set to UNKNOWN.