### PR TITLE
Memory leak on CentOS 7

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -428,6 +428,7 @@ int match_string(const char *string, const char *pattern)
 	}
 
 	status = regexec(&regex, string, 0, NULL, 0);
+	regfree(&regex);
 	if (status != 0)
 		return 0;
 


### PR DESCRIPTION
Leaks memory when running on CentOS 7 with Adaptec RAID controller present int the system.