### PR TITLE
Add option to prevent override due to sysfs

### DIFF
--- a/doc/ledmon.conf.pod
+++ b/doc/ledmon.conf.pod
@@ -79,6 +79,11 @@ is set to false - only the drive that the RAID is rebuilding to will be marked
 with appropriate LED pattern. If value is set to true all drives from RAID
 that is during rebuild will blink during this operation.
 
+B<IGNORE_RAID_STATUS> - Flag is to prevent override of ibpi request because of
+RAID process exposed via sysfs. When is set to true - requesetd pattern is forced
+upon disk instead of overriding with RAID status exposed via sysfs scan.
+Flag is applicable to ledctl only. The default value is set to false.
+
 B<WHITELIST> - Ledmon will limit changing LED state to controllers listed on
 whitelist. If any whitelist is set, only devices from list will be scanned by
 ledmon. The controllers should be separated by comma (B<,>) character.

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -182,6 +182,11 @@ static int parse_next(FILE *fd)
 		s += 10;
 		if (*s)
 			parse_list(&conf.cntrls_blacklist, s);
+	} else if (!strncmp(s, "IGNORE_RAID_STATUS=", 18)) {
+		s += 18;
+		conf.ignore_raid_status = parse_bool(s);
+		if (conf.ignore_raid_status < 0)
+			return -1;
 	} else {
 		fprintf(stderr, "config file: unknown option '%s'.\n", s);
 		return -1;
@@ -285,6 +290,8 @@ int ledmon_write_shared_conf(void)
 	snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf),
 		 "REBUILD_BLINK_ON_ALL=%d\n", conf.rebuild_blink_on_all);
 	snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf),
+		 "IGNORE_RAID_STATUS=%d\n", conf.ignore_raid_status);
+	snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf),
 		 "INTERVAL=%d\n", conf.scan_interval);
 	whitelist = conf_list_to_str(&conf.cntrls_whitelist);
 	if (whitelist) {
@@ -334,6 +341,7 @@ int main(int argc, char *argv[])
 	printf("BLINK_ON_INIT: %d\n", conf.blink_on_init);
 	printf("REBUILD_BLINK_ON_ALL: %d\n", conf.rebuild_blink_on_all);
 	printf("RAID_MEMBERS_ONLY: %d\n", conf.raid_members_only);
+	printf("IGNORE_RAID_STATUS: %d\n", conf.ignore_raid_status);
 
 	if (list_is_empty(&conf.cntrls_whitelist))
 		printf("WHITELIST: NONE\n");

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -43,6 +43,7 @@ struct ledmon_conf {
 	int blink_on_init;
 	int rebuild_blink_on_all;
 	int raid_members_only;
+	int ignore_raid_status;
 
 	/* whitelist and blacklist of controllers for blinking */
 	struct list cntrls_whitelist;

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -453,6 +453,9 @@ static status_t _ibpi_state_add_block(struct ibpi_state *state, char *name)
 		log_error("%s: device not supported", name);
 		return STATUS_NOT_SUPPORTED;
 	}
+	if (conf.ignore_raid_status) {
+		blk1->ibpi = state->ibpi;
+	}
 	blk2 = _block_device_search(&state->block_list, path);
 	if (blk2 == NULL)
 		list_append(&state->block_list, blk1);


### PR DESCRIPTION
Sysfs overrides requsted action if action holds lower priority.
Specifically, off request while raid re-build is in process is
being overridden. This patch offers option to avoid that behavior.