### PR TITLE
Default to SGPIO for AMD systems

### DIFF
--- a/src/amd.h
+++ b/src/amd.h
@@ -39,15 +39,13 @@ enum amd_led_interfaces {
 
 extern enum amd_led_interfaces amd_interface;
 
-enum amd_platforms {
+enum amd_ipmi_platforms {
 	AMD_PLATFORM_UNSET,
 	AMD_PLATFORM_ETHANOL_X,
 	AMD_PLATFORM_DAYTONA_X,
-	AMD_PLATFORM_GRANDSTAND,
-	AMD_PLATFORM_SPEEDWAY,
 };
 
-extern enum amd_platforms amd_platform;
+extern enum amd_ipmi_platforms amd_ipmi_platform;
 
 int amd_em_enabled(const char *path);
 int amd_write(struct block_device *device, enum ibpi_pattern ibpi);

--- a/src/amd_ipmi.c
+++ b/src/amd_ipmi.c
@@ -105,7 +105,7 @@ static int _get_ipmi_nvme_port(char *path)
 	/* Some platfroms require an adjustment to the port value based
 	 * on how they are numbered by the BIOS.
 	 */
-	switch (amd_platform) {
+	switch (amd_ipmi_platform) {
 	case AMD_PLATFORM_DAYTONA_X:
 		port -= 2;
 		break;
@@ -202,7 +202,7 @@ static int _ipmi_platform_channel(struct amd_drive *drive)
 {
 	int rc = 0;
 
-	switch (amd_platform) {
+	switch (amd_ipmi_platform) {
 	case AMD_PLATFORM_ETHANOL_X:
 		drive->channel =  0xd;
 		break;
@@ -222,7 +222,7 @@ static int _ipmi_platform_slave_address(struct amd_drive *drive)
 {
 	int rc = 0;
 
-	switch (amd_platform) {
+	switch (amd_ipmi_platform) {
 	case AMD_PLATFORM_ETHANOL_X:
 		drive->slave_addr = 0xc0;
 		break;
@@ -375,12 +375,12 @@ int _amd_ipmi_em_enabled(const char *path)
 		     &data_sz, &status);
 
 	if (rc) {
-		log_error("Can't determine MG9098 Status\n");
+		log_error("Can't determine MG9098 Status for AMD platform\n");
 		return 0;
 	}
 
 	if (status != 98) {
-		log_error("Not a MG9098\n");
+		log_error("Platform %s does not have a MG9098 controller\n");
 		return 0;
 	}
 


### PR DESCRIPTION
A recent update to add support for IPMI on AMD systems change
the behavior when checking for enclosure management enablement.
Previously any AMD system that returned success from
_amd_sgpio_em_enabled() would use SGPIO. The update added an explicit
check for DMI system ids that broke this behavior.

This patch corrects that behavior by defaulting to SGPIO for
AMD systems andd only using the DMI id to check for systems
known to support IPMI.

As part of this change enum amd_platform was changed to enum
amd_ipmi_platforms as we only need to track systems for IPMI.
This is needed so we can determine the correct channel and slave
address for IPMI commands.

Fixes: 2a66a3c37bbf ("Add platform check for AMD systems")

Signed-off-by: Nathan Fontenot <nathan.fontenot@amd.com>