### PR TITLE
ledctl: Correct option parsing with non-root users

### DIFF
--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -572,6 +572,8 @@ static status_t _cmdline_parse(int argc, char *argv[])
 	int opt, opt_index = -1;
 	status_t status = STATUS_SUCCESS;
 
+	optind = 1;
+
 	do {
 		opt = getopt_long(argc, argv, shortopt, longopt, &opt_index);
 		if (opt == -1)


### PR DESCRIPTION
A recent update to allow ledctl to run as non-root user does not
correctly handle calling getopt_long() twice. Before making the
second call to getopt_long() the getopt variable 'optind' needs
to be reset. Without doing this the second call to getopt_long()
fails because it believes all of the options have been parsed.

This patch resets the optind variable before the second getopt_long()
call.

Fixes: ff49cce8ec37 ("Allow to run ledctl version without root")
Signed-off-by: Nathan Fontenot <nathan.fontenot@amd.com>