### PR TITLE
Remove possibility to add NULL item into the list

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -240,11 +240,8 @@ static char *conf_list_to_str(struct list *list)
 
 	memset(buf, 0, sizeof(buf));
 	list_for_each(list, elem) {
-		if (elem) {
-			int curr = strlen(buf);
-
-			snprintf(buf + curr, sizeof(buf) - curr, "%s,", elem);
-		}
+		int curr = strlen(buf);
+		snprintf(buf + curr, sizeof(buf) - curr, "%s,", elem);
 	}
 
 	return str_dup(buf);

--- a/src/list.c
+++ b/src/list.c
@@ -59,6 +59,11 @@ void list_insert(struct list *list, void *item, struct node *after)
 	struct node *new;
 	struct node **x;
 
+	if (!item) {
+		log_error("Failed to insert item into list. NULL cannot be inserted.");
+		exit(1);
+	}
+
 	new = malloc(sizeof(struct node));
 	if (!new) {
 		log_error("Failed to allocate memory for list node.");

--- a/src/list.h
+++ b/src/list.h
@@ -37,7 +37,7 @@ struct list {
 
 #define __list_for_each_node(__list, __node, __start_fn, __iter_fn) \
 	for (struct node *__n = __start_fn(__list), *__next; \
-	     __n && (__node = __n) && ((__next = __iter_fn(__n)) || (!__next)); \
+	     __n && __n->item && (__node = __n) && (__next = __iter_fn(__n)); \
 	     __n = __next)
 
 #define list_for_each_node(__list, __node) \
@@ -48,7 +48,7 @@ struct list {
 
 #define __list_for_each(__list, __item, __start_fn, __iter_fn) \
 	for (struct node *__node = __start_fn(__list); \
-	     __node && ((__item = __node->item) || (!__node->item)); \
+	     __node && (__item = __node->item); \
 	     __node = __iter_fn(__node))
 
 #define list_for_each(__list, __item) \


### PR DESCRIPTION
It was already assumed in many places, that list won't hold NULL items.
Now they cannot be added in a standard way using list_insert().
Also it is guaranteed that NULLs won't occur in __list_for_each* macros.