### PR TITLE
Fix __list_for_each* macros.

### DIFF
--- a/src/list.h
+++ b/src/list.h
@@ -37,7 +37,7 @@ struct list {
 
 #define __list_for_each_node(__list, __node, __start_fn, __iter_fn) \
 	for (struct node *__n = __start_fn(__list), *__next; \
-	     __n && __n->item && (__node = __n) && (__next = __iter_fn(__n)); \
+	     __n && (__node = __n) && ((__next = __iter_fn(__n)) || (!__next)); \
 	     __n = __next)
 
 #define list_for_each_node(__list, __node) \
@@ -48,7 +48,7 @@ struct list {
 
 #define __list_for_each(__list, __item, __start_fn, __iter_fn) \
 	for (struct node *__node = __start_fn(__list); \
-	     __node && (__item = __node->item); \
+	     __node && ((__item = __node->item) || (!__item)); \
 	     __node = __iter_fn(__node))
 
 #define list_for_each(__list, __item) \


### PR DESCRIPTION
Let __list_for_each_node macro reach all elements (it was skipping last).
Also remove loop conditions that cause break when coming across NULL
list item.
Adding NULLs is unsupported anyways, and list_insert()
prevents it.

Signed-off-by: Mateusz Grzonka <mateusz.grzonka@intel.com>