### PR TITLE
Replace unsafe functions

### DIFF
--- a/src/amd_ipmi.c
+++ b/src/amd_ipmi.c
@@ -95,7 +95,8 @@ static int _get_ipmi_nvme_port(char *path)
 			char *dname = strrchr(dir_path, '/');
 
 			dname++;
-			port = strtol(dname, NULL, 0);
+			if (str_toi(&port, dname, NULL, 0) != 0)
+				return -1;
 			break;
 		}
 	}
@@ -148,7 +149,8 @@ static int _get_ipmi_sata_port(const char *start_path)
 
 	/* skip past 'ata' to get the ata port number */
 	t += 3;
-	port = strtoul(t, NULL, 10);
+	if (str_toi(&port, t, NULL, 10) != 0)
+		return -1;
 
 	return port;
 }
@@ -380,7 +382,7 @@ int _amd_ipmi_em_enabled(const char *path)
 	}
 
 	if (status != 98) {
-		log_error("Platform %s does not have a MG9098 controller\n");
+		log_error("Platform does not have a MG9098 controller\n");
 		return 0;
 	}
 

--- a/src/amd_sgpio.c
+++ b/src/amd_sgpio.c
@@ -569,7 +569,8 @@ static int _get_amd_sgpio_drive(const char *start_path,
 
 	/* skip past 'ata' to get the ata port number */
 	a += 3;
-	drive->ata_port = strtoul(a, NULL, 10);
+	if (str_toi(&drive->ata_port, a, NULL, 10) != 0)
+		return -1;
 
 	found = _find_file_path(ata_dir, "port_no", path, PATH_MAX);
 	if (!found) {

--- a/src/block.c
+++ b/src/block.c
@@ -190,7 +190,7 @@ struct cntrl_device *block_get_controller(const struct list *cntrl_list, char *p
 
 	list_for_each(cntrl_list, cntrl) {
 		if (strncmp(cntrl->sysfs_path, path,
-			    strlen(cntrl->sysfs_path)) == 0) {
+			    strnlen(cntrl->sysfs_path, PATH_MAX)) == 0) {
 			if (cntrl->cntrl_type == CNTRL_TYPE_NPEM)
 				return cntrl;
 			non_npem_cntrl = cntrl;

--- a/src/cntrl.c
+++ b/src/cntrl.c
@@ -119,10 +119,12 @@ static int _is_amd_nvme_cntrl(const char *path)
 	char tmp[PATH_MAX];
 	char *t;
 
+	memset(&tmp, 0, sizeof(tmp));
+
 	if (!_is_nvme_cntrl(path))
 		return 0;
 
-	sprintf(tmp, "%s", path);
+	strncpy(tmp, path, PATH_MAX - 1);
 	t = strrchr(tmp, '/');
 	if (!t)
 		return 0;
@@ -435,7 +437,7 @@ struct cntrl_device *cntrl_device_init(const char *path)
 			em_enabled = 0;
 		}
 		if (em_enabled) {
-			device = malloc(sizeof(struct cntrl_device));
+			device = calloc(1, sizeof(struct cntrl_device));
 			if (device) {
 				if (type == CNTRL_TYPE_SCSI) {
 					device->isci_present = _is_isci_cntrl(path);
@@ -445,7 +447,7 @@ struct cntrl_device *cntrl_device_init(const char *path)
 					device->hosts = NULL;
 				}
 				device->cntrl_type = type;
-				device->sysfs_path = str_dup(path);
+				strncpy(device->sysfs_path, path, PATH_MAX - 1);
 			}
 		} else {
 			log_error
@@ -463,7 +465,6 @@ struct cntrl_device *cntrl_device_init(const char *path)
 void cntrl_device_fini(struct cntrl_device *device)
 {
 	if (device) {
-		free(device->sysfs_path);
 		free_hosts(device->hosts);
 		free(device);
 	}

--- a/src/cntrl.h
+++ b/src/cntrl.h
@@ -20,6 +20,8 @@
 #ifndef _CNTRL_H_INCLUDED_
 #define _CNTRL_H_INCLUDED_
 
+#include <limits.h>
+
 /**
  * This enumeration type lists all supported storage controller types.
  */
@@ -42,7 +44,7 @@ struct cntrl_device {
 	/**
 	* Path to the device in sysfs tree.
 	*/
-	char *sysfs_path;
+	char sysfs_path[PATH_MAX];
 
 	/**
 	 * Type of storage controller device.

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -143,8 +143,8 @@ static int parse_next(FILE *fd)
 	if (!strncmp(s, "INTERVAL=", 9)) {
 		s += 9;
 		if (*s) {
-			if (sscanf(s, "%d", &conf.scan_interval) != 1 ||
-			    conf.scan_interval < LEDMON_MIN_SLEEP_INTERVAL)
+			if (str_toi(&conf.scan_interval, s, NULL, 10) != 0 ||
+				conf.scan_interval < LEDMON_MIN_SLEEP_INTERVAL)
 				conf.scan_interval = LEDMON_MIN_SLEEP_INTERVAL;
 		}
 	} else if (!strncmp(s, "LOG_LEVEL=", 10)) {

--- a/src/enclosure.c
+++ b/src/enclosure.c
@@ -110,7 +110,7 @@ static char *_get_dev_sg(const char *encl_path)
  */
 struct enclosure_device *enclosure_device_init(const char *path)
 {
-	char temp[PATH_MAX];
+	char temp[PATH_MAX] = "\0";
 	struct enclosure_device *enclosure;
 	int ret;
 	int fd;
@@ -124,7 +124,7 @@ struct enclosure_device *enclosure_device_init(const char *path)
 		goto out;
 	}
 
-	enclosure->sysfs_path = str_dup(temp);
+	memccpy(enclosure->sysfs_path, temp, '\0', PATH_MAX - 1);
 	enclosure->sas_address = _get_sas_address(temp);
 	enclosure->dev_path = _get_dev_sg(temp);
 
@@ -157,7 +157,6 @@ void enclosure_device_fini(struct enclosure_device *enclosure)
 {
 	if (enclosure) {
 		free(enclosure->slots);
-		free(enclosure->sysfs_path);
 		free(enclosure->dev_path);
 		free(enclosure);
 	}

--- a/src/enclosure.h
+++ b/src/enclosure.h
@@ -21,6 +21,7 @@
 #define _ENCLOSURE_H_INCLUDED_
 
 #include <stdint.h>
+#include <limits.h>
 
 #include "ses.h"
 
@@ -35,7 +36,7 @@ struct enclosure_device {
    * Path to an enclosure device in sysfs tree. This is controller base
    * canonical path.
    */
-	char *sysfs_path;
+	char sysfs_path[PATH_MAX];
 
   /**
    * SAS address as identifier of an enclosure.

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -441,7 +441,7 @@ static status_t _ibpi_state_add_block(struct ibpi_state *state, char *name)
 	if (strstr(temp, "/dev/") != NULL) {
 		if (stat(temp, &st) < 0)
 			return STATUS_STAT_ERROR;
-		sprintf(temp, "/sys/dev/block/%u:%u", major(st.st_rdev),
+		snprintf(temp, PATH_MAX, "/sys/dev/block/%u:%u", major(st.st_rdev),
 			minor(st.st_rdev));
 		if ((realpath(temp, path) == NULL) && (errno != ENOTDIR))
 			return STATUS_INVALID_PATH;

--- a/src/ledmon.c
+++ b/src/ledmon.c
@@ -292,9 +292,7 @@ static status_t _set_config_path(char **conf_path, const char *path)
  */
 static status_t _set_sleep_interval(const char *optarg)
 {
-	errno = 0;
-	conf.scan_interval = strtol(optarg, NULL, 10);
-	if (errno != 0) {
+	if (str_toi(&conf.scan_interval, optarg, NULL, 10) != 0) {
 		log_error("Cannot parse sleep interval");
 		return STATUS_CMDLINE_ERROR;
 	}
@@ -842,7 +840,10 @@ static void _close_parent_fds(void)
 		char *elem;
 
 		list_for_each(&dir, elem) {
-			int fd = (int)strtol(basename(elem), NULL, 10);
+			int fd;
+
+			if (str_toi(&fd, basename(elem), NULL, 10) != 0)
+				continue;
 
 			if (fd != get_log_fd())
 				close(fd);

--- a/src/npem.c
+++ b/src/npem.c
@@ -84,11 +84,16 @@ static struct pci_dev *get_pci_dev(struct pci_access *pacc, const char *path)
 {
 	unsigned int domain, bus, dev, fn;
 	char *p = strrchr(path, '/');
+	int ret = 0;
 
 	if (!p)
 		return NULL;
 
-	if (sscanf(p + 1, "%x:%x:%x.%x", &domain, &bus, &dev, &fn) != 4)
+	ret += str_toui(&domain, p + 1, &p, 16);
+	ret += str_toui(&bus, p + 1, &p, 16);
+	ret += str_toui(&dev, p + 1, &p, 16);
+	ret += str_toui(&fn, p + 1, &p, 16);
+	if (ret != 0)
 		return NULL;
 
 	return pci_get_dev(pacc, domain, bus, dev, fn);

--- a/src/pidfile.c
+++ b/src/pidfile.c
@@ -56,7 +56,7 @@ status_t pidfile_create(const char *name)
 		close(fd);
 		return STATUS_FILE_LOCK_ERROR;
 	}
-	sprintf(buf, "%d\n", getpid());
+	snprintf(buf, PATH_MAX, "%d\n", getpid());
 	count = write(fd, buf, strlen(buf));
 	close(fd);
 	return (count < 0) ? STATUS_FILE_WRITE_ERROR : STATUS_SUCCESS;
@@ -99,7 +99,8 @@ status_t pidfile_check(const char *name, pid_t *pid)
 	p = buf_read(path);
 	if (p == NULL)
 		return STATUS_INVALID_PATH;
-	tp = strtol(p, NULL, 10);
+	if (str_toi(&tp, p, NULL, 10) != 0)
+		return STATUS_DATA_ERROR;
 	if (pid)
 		*pid = tp;
 	free(p);

--- a/src/scsi.c
+++ b/src/scsi.c
@@ -157,7 +157,7 @@ char *scsi_get_host_path(const char *path, const char *ctrl_path)
 {
 	char *host;
 	char host_path[PATH_MAX] = { 0 };
-	size_t ctrl_path_len = strlen(ctrl_path);
+	size_t ctrl_path_len = strnlen(ctrl_path, PATH_MAX);
 
 	if (strncmp(path, ctrl_path, ctrl_path_len) != 0)
 		return NULL;

--- a/src/smp.c
+++ b/src/smp.c
@@ -553,7 +553,7 @@ int cntrl_init_smp(const char *path, struct cntrl_device *cntrl)
 {
 	char *path2 = NULL;
 	char *c;
-	int host, port = 0;
+	int port = 0;
 	struct dirent *de;
 	DIR *d;
 
@@ -604,8 +604,11 @@ int cntrl_init_smp(const char *path, struct cntrl_device *cntrl)
 				/* Need link called "phy-XX:Y
 				 * Y is real phy we need.
 				 * This can also be found
-				 * in phy_identifier file */
-				if (sscanf(de->d_name, "phy-%d:%d", &host, &port) != 2)
+				 * in phy_identifier file
+				 */
+				char *s = strstr(de->d_name, ":") + 1;
+
+				if (str_toi(&port, s, NULL, 10) != 0)
 					continue;
 
 				break;

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -645,9 +645,8 @@ int sysfs_enclosure_attached_to_cntrl(const char *path)
 	struct enclosure_device *device;
 
 	list_for_each(&enclo_list, device) {
-		if ((device->sysfs_path != NULL) &&
-		    (strncmp(device->sysfs_path, path, strlen(path)) == 0))
-			return 1;
+			if (strncmp(device->sysfs_path, path, strnlen(path, PATH_MAX)) == 0)
+				return 1;
 	}
 	return 0;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -308,6 +308,71 @@ char *str_cpy(char *dest, const char *src, size_t size);
 char *str_dup(const char *src);
 
 /**
+ * @brief Converts string to long integer.
+ *
+ * This function works similar to strtol.
+ * Writes to destination only if successfully read the number.
+ * Destination can be NULL if endptr is set.
+ *
+ * @param[in]      dest            Pointer to destination.
+ * @param[in]      strptr          Pointer to source string.
+ * @param[in]      endptr          Pointer to the next character in string after parsed value.
+ * @param[in]      base            Base of the numerical value in string.
+ *
+ * @return 0 if operation was successful, otherwise 1.
+ */
+int str_tol(signed long *dest, const char *strptr, char **endptr, int base);
+
+/**
+ * @brief Converts string to unsigned long integer.
+ *
+ * This function works similar to strtoul. Skips + and - characters.
+ * Writes to destination only if successfully read the number.
+ * Destination can be NULL if endptr is set.
+ *
+ * @param[in]      dest            Pointer to destination.
+ * @param[in]      strptr          Pointer to source string.
+ * @param[in]      endptr          Pointer to the next character in string after parsed value.
+ * @param[in]      base            Base of the numerical value in string.
+ *
+ * @return 0 if operation was successful, otherwise 1.
+ */
+int str_toul(unsigned long *dest, const char *strptr, char **endptr, int base);
+
+/**
+ * @brief Converts string to integer.
+ *
+ * This function works similar to strtol, but for int.
+ * Writes to destination only if successfully read the number.
+ * Destination can be NULL if endptr is set.
+ *
+ * @param[in]      dest            Pointer to destination.
+ * @param[in]      strptr          Pointer to source string.
+ * @param[in]      endptr          Pointer to the next character in string after parsed value.
+ * @param[in]      base            Base of the numerical value in string.
+ *
+ * @return 0 if operation was successful, otherwise 1.
+ */
+int str_toi(signed int *dest, const char *strptr, char **endptr, int base);
+
+/**
+ * @brief Converts string to unsigned integer.
+ *
+ * This function works similar to strtoul, but for unsigned int.
+ * Skips + and - characters.
+ * Writes to destination only if successfully read the number.
+ * Destination can be NULL if endptr is set.
+ *
+ * @param[in]      dest            Pointer to destination.
+ * @param[in]      strptr          Pointer to source string.
+ * @param[in]      endptr          Pointer to the next character in string after parsed value.
+ * @param[in]      base            Base of the numerical value in string.
+ *
+ * @return 0 if operation was successful, otherwise 1.
+ */
+int str_toui(unsigned int *dest, const char *strptr, char **endptr, int base);
+
+/**
  */
 char *truncate_path_component_rev(const char *path, int index);
 

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -151,7 +151,7 @@ int vmdssd_write(struct block_device *device, enum ibpi_pattern ibpi)
 	get_ctrl(ibpi, &val);
 	snprintf(buf, WRITE_BUFFER_SIZE, "%u", val);
 	snprintf(attention_path, PATH_MAX, "%s/attention", slot->sysfs_path);
-	if (buf_write(attention_path, buf) != (ssize_t) strlen(buf)) {
+	if (buf_write(attention_path, buf) != (ssize_t) strnlen(buf, WRITE_BUFFER_SIZE)) {
 		log_error("%s write error: %d\n", slot->sysfs_path, errno);
 		return -1;
 	}


### PR DESCRIPTION
Use safer alternatives instead of unsafe functions to avoid buffer
overflow.
Add safe wrappers for strtol family functions.
Add proper error handling for _get_slot in slave.c.