### PR TITLE
Support NVMe drive when used in user space

### DIFF
--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -436,8 +436,10 @@ static status_t _ibpi_state_add_block(struct ibpi_state *state, char *name)
 	char temp[PATH_MAX], path[PATH_MAX];
 	struct block_device *blk1, *blk2;
 
-	if ((realpath(name, temp) == NULL) && (errno != ENOTDIR))
+	if ((realpath(name, temp) == NULL) && (errno != ENOTDIR)) {
+		log_error("%s is not a valid device path.", name);
 		return STATUS_INVALID_PATH;
+	}
 	if (strstr(temp, "/dev/") != NULL) {
 		if (stat(temp, &st) < 0)
 			return STATUS_STAT_ERROR;

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -50,6 +50,11 @@ static char *get_slot_from_syspath(char *path)
 
 		if ((next != NULL) && strcmp(next, "nvme") == 0)
 			break;
+		
+		// When PCI Path is provided, last token is valid
+		// PCI path that ends with function.
+		if ((next == NULL) && (strchr(cur, '.') != NULL))
+			break;
 		cur = next;
 	}
 


### PR DESCRIPTION
NVMe drives can be used in user space, but its management can still
stay within kernel space.

Improvement to help accept device information to ledctl in order to help
leverage various LED management capababilities already supported by
this tool.

This change also allows to use kernel based drive in same fashion.
In addition allows PCIe path of NVMe to be considered as well.