### PR TITLE
Fix NULL ptr dereference and memory leak

### DIFF
--- a/src/amd_ipmi.c
+++ b/src/amd_ipmi.c
@@ -425,20 +425,16 @@ int _amd_ipmi_write(struct block_device *device, enum ibpi_pattern ibpi)
 
 char *_amd_ipmi_get_path(const char *cntrl_path, const char *sysfs_path)
 {
-	char *p, *t;
+	char *t;
 
 	/* For NVMe devices we can just dup the path sysfs path */
-	p = strstr(cntrl_path, "nvme");
-	if (p)
+	if (strstr(cntrl_path, "nvme"))
 		return strdup(sysfs_path);
 
-	/* For SATA devices we need everything up to 'ataXX/' in the path */
-	p = strdup(cntrl_path);
-	if (!p)
-		return NULL;
-
-	/* Find the beginning of the ataXX piece of the path */
-	t = strstr(p, "ata");
+	/*
+	 * For SATA devices we need everything up to 'ataXX/' in the path
+	 */
+	t = strstr(cntrl_path, "ata");
 	if (!t)
 		return NULL;
 
@@ -449,8 +445,6 @@ char *_amd_ipmi_get_path(const char *cntrl_path, const char *sysfs_path)
 	if (!t)
 		return NULL;
 
-	*++t = '\0';
-
-	return p;
+	return strndup(cntrl_path, (t - cntrl_path) + 1);
 }
 

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -240,6 +240,10 @@ static void _slave_cnt_add(const char *path, struct raid_device *raid)
 	struct slave_device *device;
 
 	char *t = strrchr(path, '/');
+
+	if (!t)
+		return;
+
 	if (strncmp(t + 1, "dev-", 4) == 0) {
 		device = slave_device_init(path, &sysfs_block_list);
 		if (device) {
@@ -355,6 +359,10 @@ static void _slots_add(const char *path)
 static void _check_raid(const char *path)
 {
 	char *t = strrchr(path, '/');
+
+	if (!t)
+		return;
+
 	if (strncmp(t + 1, "md", 2) == 0)
 		_raid_add(path);
 }


### PR DESCRIPTION
p is not freed in _amd_ipmi_get_path()
Additionally NULL ptr dereference is possible in _slave_cnt_add() and
_check_raid().

Signed-off-by: Mateusz Grzonka <mateusz.grzonka@intel.com>