### PR TITLE
Ledctl - slots management

### DIFF
--- a/doc/ledctl.pod
+++ b/doc/ledctl.pod
@@ -327,7 +327,7 @@ ledmon and exits.
 =item B<-P> or B<--list-slots> B<--controller>=I<controller>
 
 Prints all slots for the controller. Slot definition depends on the controller
-and is unique for the controller.
+and is unique across all controllers of the same type.
 
 Definitions for supported controllers are described below:
 

--- a/doc/ledctl.pod
+++ b/doc/ledctl.pod
@@ -324,6 +324,42 @@ Displays version of ledctl and information about the license and exits.
 Prints information (system path and type) of all controllers detected by
 ledmon and exits.
 
+=item B<-P> or B<--list-slots> B<--controller>=I<controller>
+
+Prints all slots for the controller. Slot definition depends on the controller
+and is unique for the controller.
+
+Definitions for supported controllers are described below:
+
+=over
+
+=item
+
+VMD - PCI Express Hot Plug Controller Driver slot number
+
+=item
+
+NPEM - PCI Express Downstream Port address
+
+=back
+
+Command returns a list of all slots for the controller with current state and
+attached device name (if any). I<controller> is type of controller
+(vmd, NPEM) that should be scanned here.
+
+=item B<-G> or B<--get-slot> B<--controller>=I<controller> B<--device>=I<device>
+
+Displays slot details of given device. I<device> is devnode of selected drive.
+
+=item B<-G> or B<--get-slot> B<--controller>=I<controller> B<--slot>=I<slot>
+
+Displays details of given slot. I<slot> is unique slot identifier.
+
+=item B<-S> or B<--set-slot> B<--controller>=I<controller> B<--slot>=I<slot> B<--state>=I<IBPI_state>
+
+Changes led state for given slot. I<controller> is type of the controller.
+I<slot> is unique slot identifier. I<IBPI_state> is led pattern.
+
 =item B<-x> or B<--listed-only>
 
 With this option ledctl will change state only on devices listed in CLI. The

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,7 @@ COMMON_SRCS      = ahci.c block.c cntrl.c config_file.c enclosure.c list.c \
                    vmdssd.h ipmi.h amd.h amd_ipmi.h npem.h
 
 LEDMON_SRCS      = ledmon.c pidfile.c $(COMMON_SRCS)
-LEDCTL_SRCS      = ledctl.c $(COMMON_SRCS)
+LEDCTL_SRCS      = ledctl.c slot.h $(COMMON_SRCS)
 
 
 sbin_PROGRAMS  = ledmon ledctl

--- a/src/block.c
+++ b/src/block.c
@@ -220,10 +220,8 @@ struct block_device *get_block_device_from_sysfs_path(char *sub_path)
 	struct block_device *device;
 
 	list_for_each(sysfs_get_block_devices(), device) {
-		if (device->sysfs_path) {
 			if (strstr(device->sysfs_path, sub_path))
 				return device;
-		}
 	}
 
 	return NULL;
@@ -434,13 +432,4 @@ int block_compare(const struct block_device *bd_old,
 		break;
 	}
 	return i;
-}
-
-status_t get_block_device_name(const struct block_device *device, char *device_name)
-{
-	if (device_name == NULL)
-		return STATUS_NULL_POINTER;
-	snprintf(device_name, PATH_MAX, "/dev/%s", basename(device->sysfs_path));
-
-	return STATUS_SUCCESS;
 }

--- a/src/block.c
+++ b/src/block.c
@@ -1,6 +1,6 @@
 /*
  * Intel(R) Enclosure LED Utilities
- * Copyright (C) 2009-2021 Intel Corporation.
+ * Copyright (C) 2009-2022 Intel Corporation.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -213,6 +213,20 @@ struct _host_type *block_get_host(struct cntrl_device *cntrl, int host_id)
 		hosts = hosts->next;
 	}
 	return hosts;
+}
+
+struct block_device *find_block_device_by_sub_path(char *sub_path)
+{
+	struct block_device *device;
+
+	list_for_each(sysfs_get_block_devices(), device) {
+		if (device->sysfs_path) {
+			if (strstr(device->sysfs_path, sub_path))
+				return device;
+		}
+	}
+
+	return NULL;
 }
 
 /*

--- a/src/block.c
+++ b/src/block.c
@@ -215,7 +215,7 @@ struct _host_type *block_get_host(struct cntrl_device *cntrl, int host_id)
 	return hosts;
 }
 
-struct block_device *find_block_device_by_sub_path(char *sub_path)
+struct block_device *get_block_device_from_sysfs_path(char *sub_path)
 {
 	struct block_device *device;
 
@@ -436,18 +436,11 @@ int block_compare(const struct block_device *bd_old,
 	return i;
 }
 
-status_t fill_block_device_name(const struct block_device *device, char *device_name)
+status_t get_block_device_name(const struct block_device *device, char *device_name)
 {
-	if (device && device->sysfs_path) {
-		char *dev_name = strrchr(device->sysfs_path, '/') + 1;
+	if (device_name == NULL)
+		return STATUS_NULL_POINTER;
+	snprintf(device_name, PATH_MAX, "/dev/%s", basename(device->sysfs_path));
 
-		if (!dev_name) {
-			log_debug("Could not parse sysfs path of the block device.");
-			return STATUS_NULL_POINTER;
-		}
-		snprintf(device_name, PATH_MAX, "/dev/%s", dev_name);
-	} else {
-		snprintf(device_name, PATH_MAX, "(empty)");
-	}
 	return STATUS_SUCCESS;
 }

--- a/src/block.c
+++ b/src/block.c
@@ -435,3 +435,19 @@ int block_compare(const struct block_device *bd_old,
 	}
 	return i;
 }
+
+status_t fill_block_device_name(const struct block_device *device, char *device_name)
+{
+	if (device && device->sysfs_path) {
+		char *dev_name = strrchr(device->sysfs_path, '/') + 1;
+
+		if (!dev_name) {
+			log_debug("Could not parse sysfs path of the block device.");
+			return STATUS_NULL_POINTER;
+		}
+		snprintf(device_name, PATH_MAX, "/dev/%s", dev_name);
+	} else {
+		snprintf(device_name, PATH_MAX, "(empty)");
+	}
+	return STATUS_SUCCESS;
+}

--- a/src/block.h
+++ b/src/block.h
@@ -25,6 +25,7 @@
 #include "time.h"
 #include "list.h"
 #include "raid.h"
+#include "status.h"
 
 struct block_device;
 
@@ -239,4 +240,13 @@ int block_compare(const struct block_device *bd_old,
  */
 struct block_device *find_block_device_by_sub_path(char *sub_path);
 
+/**
+ * @brief Fills block device name based on sysfs path to the device.
+ *
+ * @param[in]         device          Block device.
+ * @param[in]         device_name     Pointer to the block device name.
+ *
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
+ */
+status_t fill_block_device_name(const struct block_device *device, char *device_name);
 #endif				/* _BLOCK_H_INCLUDED_ */

--- a/src/block.h
+++ b/src/block.h
@@ -240,13 +240,4 @@ int block_compare(const struct block_device *bd_old,
  */
 struct block_device *get_block_device_from_sysfs_path(char *sub_path);
 
-/**
- * @brief Fills block device name based on sysfs path to the device.
- *
- * @param[in]         device          Block device.
- * @param[in]         device_name     Pointer to the block device name.
- *
- * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
- */
-status_t get_block_device_name(const struct block_device *device, char *device_name);
 #endif				/* _BLOCK_H_INCLUDED_ */

--- a/src/block.h
+++ b/src/block.h
@@ -1,6 +1,6 @@
 /*
  * Intel(R) Enclosure LED Utilities
- * Copyright (C) 2009-2018 Intel Corporation.
+ * Copyright (C) 2009-2022 Intel Corporation.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -226,5 +226,17 @@ struct _host_type *block_get_host(struct cntrl_device *cntrl, int host_id);
  */
 int block_compare(const struct block_device *bd_old,
 		  const struct block_device *bd_new);
+
+/**
+ * @brief Finds block device name containing sub-path.
+ *
+ * This function scans block devices and checks their sysfs path
+ * to find any which contains PCI address specified for device in path.
+ *
+ * @param[in]        sub_path        Sub path.
+ *
+ * @return first block device containing sub-path if any, otherwise NULL.
+ */
+struct block_device *find_block_device_by_sub_path(char *sub_path);
 
 #endif				/* _BLOCK_H_INCLUDED_ */

--- a/src/block.h
+++ b/src/block.h
@@ -229,7 +229,7 @@ int block_compare(const struct block_device *bd_old,
 		  const struct block_device *bd_new);
 
 /**
- * @brief Finds block device name containing sub-path.
+ * @brief Finds block device which name contains sub-path.
  *
  * This function scans block devices and checks their sysfs path
  * to find any which contains PCI address specified for device in path.
@@ -238,7 +238,7 @@ int block_compare(const struct block_device *bd_old,
  *
  * @return first block device containing sub-path if any, otherwise NULL.
  */
-struct block_device *find_block_device_by_sub_path(char *sub_path);
+struct block_device *get_block_device_from_sysfs_path(char *sub_path);
 
 /**
  * @brief Fills block device name based on sysfs path to the device.
@@ -248,5 +248,5 @@ struct block_device *find_block_device_by_sub_path(char *sub_path);
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t fill_block_device_name(const struct block_device *device, char *device_name);
+status_t get_block_device_name(const struct block_device *device, char *device_name);
 #endif				/* _BLOCK_H_INCLUDED_ */

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -686,12 +686,12 @@ static status_t _cmdline_parse_non_root(int argc, char *argv[])
  *
  * @return This function does not return a value.
  */
-static void slot_request_init(struct slot_request slot_req)
+static void slot_request_init(struct slot_request *slot_req)
 {
-	memset(&slot_req, 0, sizeof(struct slot_request));
+	memset(slot_req, 0, sizeof(struct slot_request));
 
-	slot_req.chosen_opt = OPT_NULL_ELEMENT;
-	slot_req.state = IBPI_PATTERN_UNKNOWN;
+	slot_req->chosen_opt = OPT_NULL_ELEMENT;
+	slot_req->state = IBPI_PATTERN_UNKNOWN;
 }
 
 /**
@@ -701,11 +701,11 @@ static void slot_request_init(struct slot_request slot_req)
  *
  * @return This function does not return a value.
  */
-static void slot_response_init(struct slot_response slot_res)
+static void slot_response_init(struct slot_response *slot_res)
 {
-	memset(&slot_res, 0, sizeof(struct slot_response));
+	memset(slot_res, 0, sizeof(struct slot_response));
 
-	slot_res.state = IBPI_PATTERN_UNKNOWN;
+	slot_res->state = IBPI_PATTERN_UNKNOWN;
 }
 
 /**
@@ -759,7 +759,7 @@ static status_t list_slots(struct slot_request *slot_req)
 		list_for_each(sysfs_get_pci_slots(), slot) {
 			struct slot_response slot_res;
 
-			slot_response_init(slot_res);
+			slot_response_init(&slot_res);
 			char *slot_num = pci_get_slot_number_from_path(slot->sysfs_path);
 
 			if (slot_num) {
@@ -791,7 +791,7 @@ status_t slot_execute(struct slot_request *slot_req)
 	struct slot_response slot_res;
 	status_t status = STATUS_SUCCESS;
 
-	slot_response_init(slot_res);
+	slot_response_init(&slot_res);
 
 	switch (slot_req->chosen_opt) {
 	case OPT_LIST_SLOTS:
@@ -1017,7 +1017,7 @@ int main(int argc, char *argv[])
 		return status;
 	if (on_exit(_ledctl_fini, progname))
 		exit(STATUS_ONEXIT_ERROR);
-	slot_request_init(slot_req);
+	slot_request_init(&slot_req);
 	status = _cmdline_parse(argc, argv, &slot_req);
 	if (status != STATUS_SUCCESS)
 		exit(STATUS_CMDLINE_ERROR);

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -778,6 +778,23 @@ static status_t list_slots(struct slot_request *slot_req)
 		}
 		return status;
 	}
+	if (strcasecmp(slot_req->ctrl_type, "npem") == 0) {
+		struct cntrl_device *ctrl_dev;
+
+		list_for_each(sysfs_get_cntrl_devices(), ctrl_dev) {
+			struct slot_response slot_res;
+
+			slot_response_init(&slot_res);
+			if (is_npem_capable(ctrl_dev->sysfs_path)) {
+				status = slot_req->get_slot_fn(NULL, ctrl_dev->sysfs_path, &slot_res);
+				if (status == STATUS_SUCCESS)
+					print_slot_state(&slot_res);
+				else
+					return status;
+			}
+		}
+		return status;
+	}
 
 	log_debug("The controller type %s does not support slots managing.", slot_req->ctrl_type);
 	return STATUS_NOT_SUPPORTED;

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -238,8 +238,11 @@ static get_slot_t _get_slot_ctrl_fn(const char *ctrl_type)
  */
 static set_slot_t _set_slot_ctrl_fn(const char *ctrl_type)
 {
-	if (strcasecmp(ctrl_type, "vmd") == 0)
+	if (strcasecmp(ctrl_type, "vmd") == 0) {
 		return pci_set_slot;
+	} else if (strcasecmp(ctrl_type, "npem") == 0) {
+		return npem_set_slot;
+	}
 	log_error("The controller type %s does not support slots managing.", ctrl_type);
 
 	return NULL;

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -1,6 +1,6 @@
 /*
  * Intel(R) Enclosure LED Utilities
- * Copyright (C) 2009-2021 Intel Corporation.
+ * Copyright (C) 2009-2022 Intel Corporation.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -96,7 +96,7 @@ const char *ibpi_str[] = {
  * information about the version of ledctl utility.
  */
 static char *ledctl_version = "Intel(R) Enclosure LED Control Application %s %s\n"
-			      "Copyright (C) 2009-2021 Intel Corporation.\n";
+			      "Copyright (C) 2009-2022 Intel Corporation.\n";
 
 /**
  * Internal variable of monitor service. It is used to help parse command line
@@ -112,6 +112,12 @@ static int possible_params[] = {
 	OPT_VERSION,
 	OPT_LIST_CTRL,
 	OPT_LISTED_ONLY,
+	OPT_LIST_SLOTS,
+	OPT_GET_SLOT,
+	OPT_SET_SLOT,
+	OPT_CONTROLLER,
+	OPT_DEVICE,
+	OPT_SLOT,
 	OPT_ALL,
 	OPT_DEBUG,
 	OPT_ERROR,
@@ -186,16 +192,25 @@ static void _ledctl_help(void)
 	       progname);
 	printf("Mandatory arguments for long options are mandatory for short options, too.\n\n");
 	print_opt("--listed-only", "-x",
-			  "Ledctl will change state only for given devices.");
+		  "Ledctl will change state only for given devices.");
 	print_opt("--list-controllers", "-L",
-			  "Displays list of controllers detected by ledmon.");
+		  "Displays list of controllers detected by ledmon.");
+	print_opt("--list-slots --controller CONTROLLER", "-P -c CONTROLLER",
+		  "List slots under the controller, their led states, slot numbers and "
+		  "devnodes connected.");
+	print_opt("--get-slot --controller CONTROLLER --device DEVNODE / --slot SLOT",
+		  "-G -c CONTROLLER -d DEVNODE / -p SLOT",
+		  "Prints slot information, its led state, slot number and devnode.");
+	print_opt("--set-slot --controller CONTROLLER --slot SLOT --state STATE",
+		  "-S -c CONTROLLER -p SLOT -s STATE", "Sets given state for chosen slot "
+		  "under the controller.");
 	print_opt("--log=PATH", "-l PATH",
-			  "Use local log file instead /var/log/ledctl.log.");
+		  "Use local log file instead /var/log/ledctl.log.");
 	print_opt("--help", "-h", "Displays this help text.");
 	print_opt("--version", "-v",
-			  "Displays version and license information.");
+		  "Displays version and license information.");
 	print_opt("--log-level=VALUE", "-l VALUE",
-			  "Allows user to set ledctl verbose level in logs.");
+		  "Allows user to set ledctl verbose level in logs.");
 	printf("\nPatterns:\n"
 	       "\tCommon patterns are:\n"
 	       "\t\tlocate, locate_off, normal, off, degraded, rebuild,\n" ""

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -44,6 +44,7 @@
 #include "config_file.h"
 #include "slot.h"
 #include "list.h"
+#include "npem.h"
 #include "pci_slot.h"
 #include "scsi.h"
 #include "status.h"
@@ -144,7 +145,7 @@ struct slot_request {
  * this entries to translate enumeration type values into the string.
  */
 const char *ibpi_str[] = {
-	[IBPI_PATTERN_UNKNOWN]        = "",
+	[IBPI_PATTERN_UNKNOWN]        = "UNKNOWN",
 	[IBPI_PATTERN_NORMAL]         = "NORMAL",
 	[IBPI_PATTERN_ONESHOT_NORMAL] = "",
 	[IBPI_PATTERN_DEGRADED]       = "ICA",
@@ -214,8 +215,11 @@ static int listed_only;
  */
 static get_slot_t _get_slot_ctrl_fn(const char *ctrl_type)
 {
-	if (strcasecmp(ctrl_type, "vmd") == 0)
+	if (strcasecmp(ctrl_type, "vmd") == 0) {
 		return pci_get_slot;
+	} else if (strcasecmp(ctrl_type, "npem") == 0) {
+		return npem_get_slot;
+	}
 	log_debug("The controller type %s does not support slots managing.", ctrl_type);
 
 	return NULL;

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -725,10 +725,10 @@ static status_t slot_verify_request(struct slot_request *slot_req)
 	if (!slot_req->get_slot_fn && !slot_req->set_slot_fn) {
 		log_error("The controller type %s doesn't support slot functionality.",
 			  slot_req->cntrl);
-		return STATUS_DATA_ERROR;
+		return STATUS_INVALID_CONTROLLER;
 	}
 	if (slot_req->device[0] && slot_req->slot[0]) {
-		log_error("Slot commands require only one from parameters: device and slot.");
+		log_error("Only one from device and slot can be set.");
 		return STATUS_DATA_ERROR;
 	}
 

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -88,13 +88,12 @@ typedef status_t (*get_slot_t) (char *device, char *slot, struct slot_response *
  *
  * The pointer to a function which will set slot details.
  *
- * @param[in]         device        Name of the device.
  * @param[in]         slot          Unique identifier of the slot.
  * @param[in]         state         IBPI state based on slot request.
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-typedef status_t (*set_slot_t) (char *device, char *slot, enum ibpi_pattern state);
+typedef status_t (*set_slot_t) (char *slot, enum ibpi_pattern state);
 
 /**
  * @brief slot request parametres
@@ -793,8 +792,7 @@ status_t slot_execute(struct slot_request *slot_req)
 			return STATUS_SUCCESS;
 		}
 		if (status == STATUS_SUCCESS)
-			status = slot_req->set_slot_fn(slot_res.device,
-						       slot_res.slot, slot_req->state);
+			status = slot_req->set_slot_fn(slot_res.slot, slot_req->state);
 		if (status != STATUS_SUCCESS)
 			return status;
 	case OPT_GET_SLOT:

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -728,7 +728,7 @@ static status_t slot_verify_request(struct slot_request *slot_req)
 		return STATUS_INVALID_CONTROLLER;
 	}
 	if (slot_req->device[0] && slot_req->slot[0]) {
-		log_error("Only one from device and slot can be set.");
+		log_error("Device and slot parameters are exclusive.");
 		return STATUS_DATA_ERROR;
 	}
 

--- a/src/npem.c
+++ b/src/npem.c
@@ -294,12 +294,12 @@ status_t npem_get_slot(char *device, char *slot_path, struct slot_response *slot
 		list_for_each(sysfs_get_cntrl_devices(), ctrl_dev) {
 			if (!is_npem_capable(ctrl_dev->sysfs_path))
 				continue;
-			if (strcmp(basename(ctrl_dev->sysfs_path), slot_path) != 0)
+			if (strcmp(basename(ctrl_dev->sysfs_path), basename(slot_path)) != 0)
 				continue;
 			path = ctrl_dev->sysfs_path;
+			block_device = get_block_device_from_sysfs_path(path);
 			break;
 		}
-		block_device = get_block_device_from_sysfs_path(path);
 	}
 	if (block_device)
 		snprintf(slot_res->device, PATH_MAX, "/dev/%s", basename(block_device->sysfs_path));

--- a/src/npem.c
+++ b/src/npem.c
@@ -296,10 +296,6 @@ status_t npem_get_slot(char *device, char *slot_path, struct slot_response *slot
 			break;
 		}
 	}
-	if (block_device)
-		snprintf(slot_res->device, PATH_MAX, "/dev/%s", basename(block_device->sysfs_path));
-	else
-		snprintf(slot_res->device, PATH_MAX, "(empty)");
 
 	if (path) {
 		pdev = get_pci_dev(pacc, path);
@@ -308,6 +304,7 @@ status_t npem_get_slot(char *device, char *slot_path, struct slot_response *slot
 		pci_cleanup(pacc);
 		return STATUS_INVALID_PATH;
 	}
+
 	if (!pdev) {
 		log_error("NPEM: Unable to get pci device for %s\n", path);
 		pci_cleanup(pacc);
@@ -317,6 +314,11 @@ status_t npem_get_slot(char *device, char *slot_path, struct slot_response *slot
 	reg = read_npem_register(pdev, PCI_NPEM_CTRL_REG);
 	slot_res->state = npem_capability_to_ibpi(reg);
 	snprintf(slot_res->slot, PATH_MAX, "%s", path);
+
+	if (block_device)
+		snprintf(slot_res->device, PATH_MAX, "/dev/%s", basename(block_device->sysfs_path));
+	else
+		snprintf(slot_res->device, PATH_MAX, "(empty)");
 
 	pci_free_dev(pdev);
 	pci_cleanup(pacc);

--- a/src/npem.h
+++ b/src/npem.h
@@ -21,9 +21,24 @@
 #define NPEM_H_INCLUDED_
 #include "block.h"
 #include "ibpi.h"
+#include "slot.h"
+#include "status.h"
 
 int is_npem_capable(const char *path);
 int npem_write(struct block_device *device, enum ibpi_pattern ibpi);
 char *npem_get_path(const char *cntrl_path);
 
+/**
+ * @brief Gets led state for slot.
+ *
+ * This function finds slot connected to given identifier
+ * and fills slot response related to the slot.
+ *
+ * @param[in]         device         Requested device name.
+ * @param[in]         slot_num       Requested identifier of the slot.
+ * @param[in]         slot_res       Pointer to the slot response.
+ *
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
+ */
+status_t npem_get_slot(char *device, char *slot_num, struct slot_response *slot_res);
 #endif // NPEM_H_INCLUDED_

--- a/src/npem.h
+++ b/src/npem.h
@@ -41,4 +41,18 @@ char *npem_get_path(const char *cntrl_path);
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
 status_t npem_get_slot(char *device, char *slot_num, struct slot_response *slot_res);
+
+/**
+ * @brief Sets led state for slot.
+ *
+ * This function finds slot connected to given number or device name
+ * and set given led state.
+ *
+ * @param[in]         device         Requested device name.
+ * @param[in]         slot_num       Requested number of the slot.
+ * @param[in]         state          IBPI state based on slot request.
+ *
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
+ */
+status_t npem_set_slot(char *device, char *slot_num, enum ibpi_pattern state);
 #endif // NPEM_H_INCLUDED_

--- a/src/npem.h
+++ b/src/npem.h
@@ -48,11 +48,10 @@ status_t npem_get_slot(char *device, char *slot_num, struct slot_response *slot_
  * This function finds slot connected to given number or device name
  * and set given led state.
  *
- * @param[in]         device         Requested device name.
  * @param[in]         slot_num       Requested number of the slot.
  * @param[in]         state          IBPI state based on slot request.
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t npem_set_slot(char *device, char *slot_num, enum ibpi_pattern state);
+status_t npem_set_slot(char *slot_num, enum ibpi_pattern state);
 #endif // NPEM_H_INCLUDED_

--- a/src/pci_slot.c
+++ b/src/pci_slot.c
@@ -130,9 +130,13 @@ status_t pci_get_slot(char *device, char *slot_num, struct slot_response *slot_r
 	struct block_device *block_device = NULL;
 
 	if (device && device[0] != '\0') {
-		char *sub_path = strrchr(device, '/') + 1;
+		char *sub_path = strrchr(device, '/');
+		if (sub_path == NULL) {
+			log_error("Device name %s is invalid.", device);
+			return STATUS_CMDLINE_ERROR;
+		}
 
-		block_device = find_block_device_by_sub_path(sub_path);
+		block_device = find_block_device_by_sub_path(sub_path + 1);
 		if (block_device) {
 			slot = vmdssd_find_pci_slot(block_device->sysfs_path);
 		} else {

--- a/src/pci_slot.c
+++ b/src/pci_slot.c
@@ -119,21 +119,9 @@ static status_t set_slot_parameters(struct pci_slot *slot, struct slot_response 
 		return STATUS_NULL_POINTER;
 	}
 	snprintf(slot_res->slot, PATH_MAX, "%s", slot_num);
-
 	bl_device = find_block_device_by_sub_path(slot->address);
-	if (bl_device && bl_device->sysfs_path) {
-		char *dev_name = strrchr(bl_device->sysfs_path, '/') + 1;
 
-		if (!dev_name) {
-			log_debug("Could not parse sysfs path of the block device.");
-			return STATUS_NULL_POINTER;
-		}
-		snprintf(slot_res->device, PATH_MAX, "/dev/%s", dev_name);
-	} else {
-		snprintf(slot_res->device, PATH_MAX, "(empty)");
-	}
-
-	return STATUS_SUCCESS;
+	return fill_block_device_name(bl_device, slot_res->device);
 }
 
 status_t pci_get_slot(char *device, char *slot_num, struct slot_response *slot_res)

--- a/src/pci_slot.c
+++ b/src/pci_slot.c
@@ -102,7 +102,7 @@ static status_t set_slot_response(struct pci_slot *slot, struct slot_response *s
 	if (attention == -1)
 		return STATUS_INVALID_STATE;
 
-	slot_res->state = attention_to_ibpi(attention);
+	slot_res->state = get_ibpi_for_value(attention, ibpi_to_attention);
 	snprintf(slot_res->slot, PATH_MAX, "%s", basename(slot->sysfs_path));
 
 	bl_device = get_block_device_from_sysfs_path(slot->address);

--- a/src/pci_slot.c
+++ b/src/pci_slot.c
@@ -133,10 +133,9 @@ status_t pci_get_slot(char *device, char *slot_path, struct slot_response *slot_
 			return STATUS_DATA_ERROR;
 		}
 		slot = vmdssd_find_pci_slot(block_device->sysfs_path);
-	}
-
-	if (slot_path && slot_path[0] != '\0')
+	} else if (slot_path && slot_path[0] != '\0') {
 		slot = find_pci_slot_by_number(basename(slot_path));
+	}
 
 	if (slot == NULL) {
 		log_error("Specified slot was not found.");

--- a/src/pci_slot.c
+++ b/src/pci_slot.c
@@ -46,12 +46,6 @@ struct pci_slot *pci_slot_init(const char *path)
 		return NULL;
 	result->sysfs_path = str_dup(path);
 	result->address = get_text(path, "address");
-	result->attention = get_int(path, -1, "attention");
-
-	if (result->attention == -1) {
-		pci_slot_fini(result);
-		return NULL;
-	}
 
 	return result;
 }
@@ -67,17 +61,6 @@ void pci_slot_fini(struct pci_slot *slot)
 		free(slot->address);
 		free(slot);
 	}
-}
-
-/**
- * Finds slot identifier in sysfs path.
- */
-char *pci_get_slot_number_from_path(const char *sysfs_path)
-{
-	if (sysfs_path)
-		return strrchr(sysfs_path, '/') + 1;
-
-	return NULL;
 }
 
 /**

--- a/src/pci_slot.c
+++ b/src/pci_slot.c
@@ -93,7 +93,7 @@ static struct pci_slot *find_pci_slot_by_number(char *slot_number)
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-static status_t set_slot_parameters(struct pci_slot *slot, struct slot_response *slot_res)
+static status_t set_slot_response(struct pci_slot *slot, struct slot_response *slot_res)
 {
 	struct block_device *bl_device;
 	status_t status = STATUS_SUCCESS;
@@ -103,9 +103,8 @@ static status_t set_slot_parameters(struct pci_slot *slot, struct slot_response 
 		return STATUS_INVALID_STATE;
 
 	slot_res->state = attention_to_ibpi(attention);
-	char* slot_num = basename(slot->sysfs_path);
+	snprintf(slot_res->slot, PATH_MAX, "%s", basename(slot->sysfs_path));
 
-	snprintf(slot_res->slot, PATH_MAX, "%s", slot_num);
 	bl_device = get_block_device_from_sysfs_path(slot->address);
 	if (bl_device)
 		snprintf(slot_res->device, PATH_MAX, "/dev/%s", basename(bl_device->sysfs_path));
@@ -142,7 +141,7 @@ status_t pci_get_slot(char *device, char *slot_path, struct slot_response *slot_
 		return STATUS_DATA_ERROR;
 	}
 
-	return set_slot_parameters(slot, slot_res);
+	return set_slot_response(slot, slot_res);
 }
 
 status_t pci_set_slot(char *slot_path, enum ibpi_pattern state)

--- a/src/pci_slot.c
+++ b/src/pci_slot.c
@@ -101,7 +101,7 @@ static status_t set_slot_parameters(struct pci_slot *slot, struct slot_response 
 	snprintf(slot_res->slot, PATH_MAX, "%s", slot_num);
 	bl_device = get_block_device_from_sysfs_path(slot->address);
 	if (bl_device)
-		status = get_block_device_name(bl_device, slot_res->device);
+		snprintf(slot_res->device, PATH_MAX, "/dev/%s", basename(bl_device->sysfs_path));
 	else
 		snprintf(slot_res->device, PATH_MAX, "(empty)");
 

--- a/src/pci_slot.c
+++ b/src/pci_slot.c
@@ -29,7 +29,9 @@
 
 #include "config.h"
 #include "pci_slot.h"
+#include "sysfs.h"
 #include "utils.h"
+#include "vmdssd.h"
 
 /*
  * Allocates memory for PCI hotplug slot structure and initializes fields of
@@ -64,5 +66,93 @@ void pci_slot_fini(struct pci_slot *slot)
 		free(slot->sysfs_path);
 		free(slot->address);
 		free(slot);
+	}
+}
+
+/**
+ * @brief Finds PCI slot by number of the slot.
+ *
+ * @param[in]       slot_number       Number of the slot
+ *
+ * @return Struct with pci slot if successful, otherwise the function returns NULL pointer.
+ */
+static struct pci_slot *find_pci_slot_by_number(char *slot_number)
+{
+	struct pci_slot *slot = NULL;
+	char *temp;
+
+	list_for_each(sysfs_get_pci_slots(), slot) {
+		if (slot->sysfs_path) {
+			temp = strrchr(slot->sysfs_path, '/') + 1;
+			if (temp && strncmp(temp, slot_number, PATH_MAX) == 0)
+				return slot;
+		}
+	}
+	return NULL;
+}
+
+/**
+ * @brief Sets the slot response.
+ *
+ * @param[in]        slot       Struct with PCI slot parameters.
+ *
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
+ */
+static status_t set_slot_parameters(struct pci_slot *slot, struct slot_response *slot_res)
+{
+	struct block_device *bl_device;
+
+	slot_res->state = attention_to_ibpi(get_int(slot->sysfs_path, -1, "attention"));
+	if (slot->sysfs_path) {
+		char* slot_num = strrchr(slot->sysfs_path, '/') + 1;
+
+		if (!slot_num) {
+			log_debug("Could not parse sysfs path of the pci slot.");
+			return STATUS_NULL_POINTER;
+		}
+		snprintf(slot_res->slot, PATH_MAX, "%s", slot_num);
+	}
+
+	bl_device = find_block_device_by_sub_path(slot->address);
+	if (bl_device && bl_device->sysfs_path) {
+		char *dev_name = strrchr(bl_device->sysfs_path, '/') + 1;
+
+		if (!dev_name) {
+			log_debug("Could not parse sysfs path of the block device.");
+			return STATUS_NULL_POINTER;
+		}
+		snprintf(slot_res->device, PATH_MAX, "/dev/%s", dev_name);
+	} else {
+		snprintf(slot_res->device, PATH_MAX, "(empty)");
+	}
+
+	return STATUS_SUCCESS;
+}
+
+status_t pci_get_slot(char *device, char *slot_num, struct slot_response *slot_res)
+{
+	struct pci_slot *slot = NULL;
+	struct block_device *block_device = NULL;
+
+	if (device[0] != '\0') {
+		char *sub_path = strrchr(device, '/') + 1;
+
+		block_device = find_block_device_by_sub_path(sub_path);
+		if (block_device) {
+			slot = vmdssd_find_pci_slot(block_device->sysfs_path);
+		} else {
+			log_error("Device %s not found.", device);
+			return STATUS_NULL_POINTER;
+		}
+	}
+
+	if (device[0] != '\0')
+		slot = find_pci_slot_by_number(slot_num);
+
+	if (slot) {
+		return set_slot_parameters(slot, slot_res);
+	} else {
+		log_error("Slot %s not found.", slot_num);
+		return STATUS_NULL_POINTER;
 	}
 }

--- a/src/pci_slot.h
+++ b/src/pci_slot.h
@@ -20,6 +20,7 @@
 #ifndef PCI_SLOT_H_INCLUDED_
 #define PCI_SLOT_H_INCLUDED_
 
+#include "ibpi.h"
 #include "slot.h"
 #include "status.h"
 
@@ -95,4 +96,17 @@ status_t pci_get_slot(char *device, char *slot_num, struct slot_response *slot_r
  */
 char *pci_get_slot_number_from_path(const char *sysfs_path);
 
+/**
+ * @brief Sets led state for slot.
+ *
+ * This function finds slot connected to given number or device name
+ * and set given led state.
+ *
+ * @param[in]         device         Requested device name.
+ * @param[in]         slot_num       Requested number of the slot.
+ * @param[in]         state          IBPI state based on slot request.
+ *
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
+ */
+status_t pci_set_slot(char *device, char *slot_num, enum ibpi_pattern state);
 #endif // PCI_SLOT_H_INCLUDED_

--- a/src/pci_slot.h
+++ b/src/pci_slot.h
@@ -39,11 +39,6 @@ struct pci_slot {
  * PCI hotplug slot address.
  */
 	char *address;
-
- /**
- * State of the Amber LED of the PCI slot.
- */
-	int attention;
 };
 
 /**
@@ -86,15 +81,6 @@ void pci_slot_fini(struct pci_slot *slot);
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
 status_t pci_get_slot(char *device, char *slot_num, struct slot_response *slot_res);
-
-/**
- * @brief Finds slot identifier in sysfs path.
- *
- * @param[in]         sysfs_path     Path to the slot in sysfs.
- *
- * @return Slot identifier.
- */
-char *pci_get_slot_number_from_path(const char *sysfs_path);
 
 /**
  * @brief Sets led state for slot.

--- a/src/pci_slot.h
+++ b/src/pci_slot.h
@@ -20,6 +20,9 @@
 #ifndef PCI_SLOT_H_INCLUDED_
 #define PCI_SLOT_H_INCLUDED_
 
+#include "slot.h"
+#include "status.h"
+
 /**
  * @brief PCI hotplug slot structure.
  *
@@ -68,5 +71,19 @@ struct pci_slot *pci_slot_init(const char *path);
  * @return The function does not return a value.
  */
 void pci_slot_fini(struct pci_slot *slot);
+
+/**
+ * @brief Gets led state for slot.
+ *
+ * This function finds slot connected to given identifier
+ * and fills slot response related to the slot.
+ *
+ * @param[in]         device         Requested device name.
+ * @param[in]         slot_num       Requested identifier of the slot.
+ * @param[in]         slot_res       Pointer to the slot response.
+ *
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
+ */
+status_t pci_get_slot(char *device, char *slot_num, struct slot_response *slot_res);
 
 #endif // PCI_SLOT_H_INCLUDED_

--- a/src/pci_slot.h
+++ b/src/pci_slot.h
@@ -88,11 +88,10 @@ status_t pci_get_slot(char *device, char *slot_num, struct slot_response *slot_r
  * This function finds slot connected to given number or device name
  * and set given led state.
  *
- * @param[in]         device         Requested device name.
  * @param[in]         slot_num       Requested number of the slot.
  * @param[in]         state          IBPI state based on slot request.
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t pci_set_slot(char *device, char *slot_num, enum ibpi_pattern state);
+status_t pci_set_slot(char *slot_num, enum ibpi_pattern state);
 #endif // PCI_SLOT_H_INCLUDED_

--- a/src/pci_slot.h
+++ b/src/pci_slot.h
@@ -86,4 +86,13 @@ void pci_slot_fini(struct pci_slot *slot);
  */
 status_t pci_get_slot(char *device, char *slot_num, struct slot_response *slot_res);
 
+/**
+ * @brief Finds slot identifier in sysfs path.
+ *
+ * @param[in]         sysfs_path     Path to the slot in sysfs.
+ *
+ * @return Slot identifier.
+ */
+char *pci_get_slot_number_from_path(const char *sysfs_path);
+
 #endif // PCI_SLOT_H_INCLUDED_

--- a/src/slot.h
+++ b/src/slot.h
@@ -1,0 +1,63 @@
+/*
+ * Intel(R) Enclosure LED Utilities
+ * Copyright (C) 2022-2022 Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef SLOT_H_
+#define SLOT_H_
+
+#include <stdio.h>
+
+#include "ibpi.h"
+#include "utils.h"
+
+/**
+ * @brief slot response parameters
+ *
+ * This structure contains slot properties.
+ */
+struct slot_response {
+	/**
+	 * Name of the device.
+	 */
+	char device[PATH_MAX];
+
+	/**
+	 * Unique slot identifier.
+	 */
+	char slot[PATH_MAX];
+
+	/**
+	 * IBPI state.
+	 */
+	enum ibpi_pattern state;
+};
+
+/**
+ * @brief Print address, slot identifier and led state.
+ *
+ * @param[in]        res        Structure with slot response.
+ *
+ * @return This function does not return a value.
+ */
+static inline void print_slot_state(struct slot_response *res)
+{
+	printf("slot: %s, led state: %s, device %s\n",
+	       res->slot, ibpi2str(res->state), res->device);
+}
+
+#endif // SLOT_H_INCLUDED_

--- a/src/slot.h
+++ b/src/slot.h
@@ -56,8 +56,8 @@ struct slot_response {
  */
 static inline void print_slot_state(struct slot_response *res)
 {
-	printf("slot: %s, led state: %s, device %s\n",
-	       res->slot, ibpi2str(res->state), res->device);
+	printf("slot: %-15s led state: %-15s device: %-15s\n",
+	       basename(res->slot), ibpi2str(res->state), res->device);
 }
 
 #endif // SLOT_H_INCLUDED_

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -48,7 +48,6 @@
  */
 #define SYSFS_CLASS_BLOCK       "/sys/block"
 #define SYSFS_CLASS_ENCLOSURE   "/sys/class/enclosure"
-#define SYSFS_PCI_DEVICES       "/sys/bus/pci/devices"
 #define SYSFS_PCI_SLOTS         "/sys/bus/pci/slots"
 
 /**

--- a/src/sysfs.h
+++ b/src/sysfs.h
@@ -1,6 +1,6 @@
 /*
  * Intel(R) Enclosure LED Utilities
- * Copyright (C) 2009-2018 Intel Corporation.
+ * Copyright (C) 2009-2022 Intel Corporation.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -21,6 +21,8 @@
 #define _SYSFS_H_INCLUDED_
 
 #include "status.h"
+
+#define SYSFS_PCI_DEVICES       "/sys/bus/pci/devices"
 
 /**
  * @brief Initializes sysfs module.

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,6 +1,6 @@
 /*
  * Intel(R) Enclosure LED Utilities
- * Copyright (C) 2009-2021 Intel Corporation.
+ * Copyright (C) 2009-2022 Intel Corporation.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -505,7 +505,7 @@ int get_log_fd(void)
 
 void print_opt(const char *long_opt, const char *short_opt, const char *desc)
 {
-	printf("%-20s%-10s%s\n", long_opt, short_opt, desc);
+	printf("%-70s%-40s%s\n", long_opt, short_opt, desc);
 }
 
 /**
@@ -581,6 +581,13 @@ struct option longopt_all[] = {
 	[OPT_LIST_CTRL]    = {"list-controllers", no_argument, NULL, 'L'},
 	[OPT_LISTED_ONLY]  = {"listed-only", no_argument, NULL, 'x'},
 	[OPT_FOREGROUND]   = {"foreground", no_argument, NULL, '\0'},
+	[OPT_LIST_SLOTS]   = {"list-slots", no_argument, NULL, 'P'},
+	[OPT_GET_SLOT]     = {"get-slot", no_argument, NULL, 'G'},
+	[OPT_SET_SLOT]     = {"set-slot", no_argument, NULL, 'S'},
+	[OPT_CONTROLLER]   = {"controller", required_argument, NULL, 'c'},
+	[OPT_DEVICE]       = {"device", required_argument, NULL, 'd'},
+	[OPT_SLOT]         = {"slot", required_argument, NULL, 'p'},
+	[OPT_STATE]        = {"state", required_argument, NULL, 's'},
 	[OPT_NULL_ELEMENT] = {NULL, no_argument, NULL, '\0'}
 };
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -706,3 +706,15 @@ const char *ibpi2str(enum ibpi_pattern ibpi)
 
 	return ret;
 }
+
+int get_value_for_ibpi(enum ibpi_pattern ibpi, const struct ibpi_value ibpi_values[])
+{
+	const struct ibpi_value *tmp = ibpi_values;
+
+	while (tmp->ibpi != IBPI_PATTERN_UNKNOWN) {
+		if (tmp->ibpi == ibpi)
+			break;
+		tmp++;
+	}
+	return tmp->value;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -707,6 +707,14 @@ const char *ibpi2str(enum ibpi_pattern ibpi)
 	return ret;
 }
 
+/**
+ * @brief Returns value based on IBPI state
+ *
+ * @param[in]       value       Value for led state.
+ * @param[in]       ibpi_values    Array with defined IBPI states and values.
+ *
+ * @return Integer value which represents given IBPI state.
+ */
 int get_value_for_ibpi(enum ibpi_pattern ibpi, const struct ibpi_value ibpi_values[])
 {
 	const struct ibpi_value *tmp = ibpi_values;
@@ -717,4 +725,24 @@ int get_value_for_ibpi(enum ibpi_pattern ibpi, const struct ibpi_value ibpi_valu
 		tmp++;
 	}
 	return tmp->value;
+}
+
+/**
+ * @brief Returns IBPI pattern based on value
+ *
+ * @param[in]       value          Value for led state.
+ * @param[in]       ibpi_values    Array with defined IBPI states and values.
+ *
+ * @return Enum with IBPI value, which represents given value.
+ */
+enum ibpi_pattern get_ibpi_for_value(const int value, const struct ibpi_value ibpi_values[])
+{
+	const struct ibpi_value *tmp = ibpi_values;
+
+	while (tmp->ibpi != IBPI_PATTERN_UNKNOWN) {
+		if (tmp->value == value)
+			break;
+		tmp++;
+	}
+	return tmp->ibpi;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -46,8 +46,6 @@
  */
 #define WRITE_BUFFER_SIZE   1024
 
-#define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
-
 /**
  * This structure describes a device identifier. It consists of major and minor
  * attributes of device.
@@ -442,5 +440,6 @@ status_t set_verbose_level(int log_level);
 
 const char *ibpi2str(enum ibpi_pattern ibpi);
 int get_value_for_ibpi(enum ibpi_pattern ibpi, const struct ibpi_value ibpi_values[]);
+enum ibpi_pattern get_ibpi_for_value(const int value, const struct ibpi_value ibpi_values[]);
 
 #endif				/* _UTILS_H_INCLUDED_ */

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,6 +1,6 @@
 /*
  * Intel(R) Enclosure LED Utilities
- * Copyright (C) 2009-2019 Intel Corporation.
+ * Copyright (C) 2009-2022 Intel Corporation.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -418,6 +418,13 @@ enum opt {
 	OPT_LIST_CTRL,
 	OPT_LISTED_ONLY,
 	OPT_FOREGROUND,
+	OPT_LIST_SLOTS,
+	OPT_GET_SLOT,
+	OPT_SET_SLOT,
+	OPT_CONTROLLER,
+	OPT_DEVICE,
+	OPT_SLOT,
+	OPT_STATE,
 	OPT_NULL_ELEMENT
 };
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -46,6 +46,8 @@
  */
 #define WRITE_BUFFER_SIZE   1024
 
+#define ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
+
 /**
  * This structure describes a device identifier. It consists of major and minor
  * attributes of device.
@@ -57,6 +59,10 @@ struct device_id {
 struct log_level_info {
 	char prefix[10];
 	int priority;
+};
+
+struct ibpi_value {
+	int ibpi, value;
 };
 
 /**

--- a/src/utils.h
+++ b/src/utils.h
@@ -441,5 +441,6 @@ int get_option_id(const char *optarg);
 status_t set_verbose_level(int log_level);
 
 const char *ibpi2str(enum ibpi_pattern ibpi);
+int get_value_for_ibpi(enum ibpi_pattern ibpi, const struct ibpi_value ibpi_values[]);
 
 #endif				/* _UTILS_H_INCLUDED_ */

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -1,6 +1,6 @@
 /*
  * Intel(R) Enclosure LED Utilities
- * Copyright (c) 2016-2019, Intel Corporation
+ * Copyright (c) 2016-2022, Intel Corporation
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -76,6 +76,30 @@ static void get_ctrl(enum ibpi_pattern ibpi, uint16_t *new)
 	default:
 		*new = ATTENTION_OFF;
 		break;
+	}
+}
+
+/**
+ * @brief Returns IBPI pattern based on attention state
+ *
+ * @param[in]       attention       Attention state.
+ *
+ * @return Enum with IBPI value.
+ */
+enum ibpi_pattern attention_to_ibpi(const int attention)
+{
+	switch (attention) {
+	case ATTENTION_FAILURE:
+		return IBPI_PATTERN_FAILED_DRIVE;
+	case ATTENTION_LOCATE:
+		return IBPI_PATTERN_LOCATE;
+	case ATTENTION_REBUILD:
+		return IBPI_PATTERN_REBUILD;
+	case ATTENTION_OFF:
+		return IBPI_PATTERN_LOCATE_OFF;
+	default:
+		log_debug("Attention %d cannot be transferred to IBPI state.", attention);
+		return IBPI_PATTERN_UNKNOWN;
 	}
 }
 

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -150,6 +150,8 @@ status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum ibpi_pattern ibp
 	char buf[WRITE_BUFFER_SIZE];
 	uint16_t val;
 
+	log_debug("%s before: 0x%x\n", slot->address,
+		  get_int(slot->sysfs_path, 0, "attention"));
 	get_ctrl(ibpi, &val);
 	snprintf(buf, WRITE_BUFFER_SIZE, "%u", val);
 	snprintf(attention_path, PATH_MAX, "%s/attention", slot->sysfs_path);
@@ -157,6 +159,8 @@ status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum ibpi_pattern ibp
 		log_error("%s write error: %d\n", slot->sysfs_path, errno);
 		return STATUS_FILE_WRITE_ERROR;
 	}
+	log_debug("%s after: 0x%x\n", slot->address,
+		  get_int(slot->sysfs_path, 0, "attention"));
 
 	return STATUS_SUCCESS;
 }
@@ -164,7 +168,6 @@ status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum ibpi_pattern ibp
 int vmdssd_write(struct block_device *device, enum ibpi_pattern ibpi)
 {
 	struct pci_slot *slot;
-	status_t status = STATUS_SUCCESS;
 	char *short_name = strrchr(device->sysfs_path, '/');
 
 	if (short_name)
@@ -184,17 +187,7 @@ int vmdssd_write(struct block_device *device, enum ibpi_pattern ibpi)
 		__set_errno_and_return(ENODEV);
 	}
 
-	log_debug("%s before: 0x%x\n", short_name,
-		  get_int(slot->sysfs_path, 0, "attention"));
-
-	status = vmdssd_write_attention_buf(slot, ibpi);
-	if (status != STATUS_SUCCESS)
-		return status;
-
-	log_debug("%s after: 0x%x\n", short_name,
-		  get_int(slot->sysfs_path, 0, "attention"));
-
-	return STATUS_SUCCESS;
+	return vmdssd_write_attention_buf(slot, ibpi);
 }
 
 char *vmdssd_get_path(const char *cntrl_path)

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -73,13 +73,15 @@ static void get_ctrl(enum ibpi_pattern ibpi, uint16_t *new)
 	const struct ibpi_value *tmp = NULL;
 	int i = 0;
 
-	for (i = 0; i < ARRAY_SIZE(ibpi_to_attention); i++) {
+	while (i < ARRAY_SIZE(ibpi_to_attention)) {
 		tmp = &ibpi_to_attention[i];
 		if (tmp->ibpi == ibpi) {
 			*new = tmp->value;
 			return;
 		}
+		i++;
 	}
+
 	*new = ATTENTION_OFF;
 }
 
@@ -95,11 +97,13 @@ enum ibpi_pattern attention_to_ibpi(const int attention)
 	const struct ibpi_value *tmp = NULL;
 	int i = 0;
 
-	for (i = 0; i < ARRAY_SIZE(ibpi_to_attention); i++) {
+	while (i < ARRAY_SIZE(ibpi_to_attention)) {
 		tmp = &ibpi_to_attention[i];
 		if (attention == tmp->value)
 			return tmp->ibpi;
+		i++;
 	}
+
 	return IBPI_PATTERN_UNKNOWN;
 }
 

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -68,25 +68,6 @@ static char *get_slot_from_syspath(char *path)
 	return ret;
 }
 
-/**
- * @brief Returns IBPI pattern based on attention state
- *
- * @param[in]       attention       Attention state.
- *
- * @return Enum with IBPI value.
- */
-enum ibpi_pattern attention_to_ibpi(const int attention)
-{
-	const struct ibpi_value *tmp = ibpi_to_attention;
-
-	while (tmp->ibpi != IBPI_PATTERN_UNKNOWN) {
-		if (tmp->value == attention)
-			break;
-		tmp++;
-	}
-	return tmp->ibpi;
-}
-
 static int check_slot_module(const char *slot_path)
 {
 	char module_path[PATH_MAX], real_module_path[PATH_MAX];

--- a/src/vmdssd.h
+++ b/src/vmdssd.h
@@ -27,5 +27,6 @@ int vmdssd_write(struct block_device *device, enum ibpi_pattern ibpi);
 char *vmdssd_get_path(const char *cntrl_path);
 struct pci_slot *vmdssd_find_pci_slot(char *device_path);
 enum ibpi_pattern attention_to_ibpi(const int attention);
+status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum ibpi_pattern ibpi);
 
 #endif

--- a/src/vmdssd.h
+++ b/src/vmdssd.h
@@ -22,11 +22,18 @@
 
 #include "block.h"
 #include "ibpi.h"
+#include "utils.h"
+
+#define ATTENTION_OFF        0xF  /* (1111) Attention Off, Power Off */
+#define ATTENTION_LOCATE     0x7  /* (0111) Attention Off, Power On */
+#define ATTENTION_REBUILD    0x5  /* (0101) Attention On, Power On */
+#define ATTENTION_FAILURE    0xD  /* (1101) Attention On, Power Off */
+
+extern struct ibpi_value ibpi_to_attention[];
 
 int vmdssd_write(struct block_device *device, enum ibpi_pattern ibpi);
 char *vmdssd_get_path(const char *cntrl_path);
 struct pci_slot *vmdssd_find_pci_slot(char *device_path);
-enum ibpi_pattern attention_to_ibpi(const int attention);
 status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum ibpi_pattern ibpi);
 
 #endif

--- a/src/vmdssd.h
+++ b/src/vmdssd.h
@@ -1,6 +1,6 @@
 /*
  * Intel(R) Enclosure LED Utilities
- * Copyright (c) 2016-2019, Intel Corporation
+ * Copyright (c) 2016-2022, Intel Corporation
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -26,5 +26,6 @@
 int vmdssd_write(struct block_device *device, enum ibpi_pattern ibpi);
 char *vmdssd_get_path(const char *cntrl_path);
 struct pci_slot *vmdssd_find_pci_slot(char *device_path);
+enum ibpi_pattern attention_to_ibpi(const int attention);
 
 #endif


### PR DESCRIPTION
Introduction of new interface which will enable to use ledctl for manage slots directly. It enables to use ledctl with empty slots.
New commands, which will be added:
- get-slot, which will print details about specified slot,
- set-slot, which will set led state for specified slot,
- list-slots, which will print details about all of the slots for chosen controller.
NPEM and VMD are controller types which will be supported now.