### PR TITLE
Fix cache indexing of ata port

### DIFF
--- a/src/amd_sgpio.c
+++ b/src/amd_sgpio.c
@@ -275,7 +275,7 @@ static struct cache_entry *_get_cache(struct amd_drive *drive)
 	 *	cache_entry[n] => drive (4*n) to drive (4*n + 3)
 	 */
 
-	index = (drive->ata_port / 4);
+	index = ((drive->ata_port - 1) / 4);
 
 	return &sgpio_cache[index];
 }


### PR DESCRIPTION
Ata port number is 1-based indexing. Need to minus 1 to fit 0-based cache array index.