### PR TITLE
Change stdout to stderr

### DIFF
--- a/src/config_file.c
+++ b/src/config_file.c
@@ -205,14 +205,14 @@ int ledmon_read_config(const char *filename)
 
 	if (!filename || (filename && access(filename, F_OK) < 0)) {
 		if (filename)
-			fprintf(stdout, "%s: does not exist, using global config file\n",
+			fprintf(stderr, "%s: does not exist, using global config file\n",
 				filename);
 		filename = LEDMON_DEF_CONF_FILE;
 	}
 
 	f = fopen(filename, "re");
 	if (!f) {
-		fprintf(stdout, "%s: does not exist, using built-in defaults\n",
+		fprintf(stderr, "%s: does not exist, using built-in defaults\n",
 			filename);
 	} else {
 		while (!feof(f)) {
@@ -228,7 +228,7 @@ int ledmon_read_config(const char *filename)
 
 	if (!list_is_empty(&conf.cntrls_whitelist) &&
 	    !list_is_empty(&conf.cntrls_blacklist))
-		fprintf(stdout, "Both whitelist and blacklist are specified - ignoring blacklist.");
+		fprintf(stderr, "Both whitelist and blacklist are specified - ignoring blacklist.");
 
 	return STATUS_SUCCESS;
 }


### PR DESCRIPTION
Standard output messages stopped appearing in systemctl status and journalctl. They do appear only after the service is terminated.
Changing the stream to standard error is more suited in the given cases and makes the messages appear in service log immediately.

Signed-off-by: Lukasz Florczak <lukasz.florczak@linux.intel.com>