### PR TITLE
SES slot get/set/list support and bug fixes

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -153,7 +153,7 @@ static char *_get_host(char *path, struct cntrl_device *cntrl)
 		result = npem_get_path(cntrl->sysfs_path);
 	else if (cntrl->cntrl_type == CNTRL_TYPE_AMD)
 		result = amd_get_path(path, cntrl->sysfs_path);
-  
+
 	return result;
 }
 
@@ -221,8 +221,12 @@ struct block_device *get_block_device_from_sysfs_path(char *sub_path)
 	struct block_device *device;
 
 	list_for_each(sysfs_get_block_devices(), device) {
-			if (strstr(device->sysfs_path, sub_path))
-				return device;
+			char *start_loc;
+			if ((start_loc = strstr(device->sysfs_path, sub_path))) {
+				char following = start_loc[strnlen(sub_path, PATH_MAX)];
+				if (following == '/' || following == '\n' || following == '\0')
+					return device;
+			}
 	}
 
 	return NULL;

--- a/src/block.h
+++ b/src/block.h
@@ -234,6 +234,8 @@ int block_compare(const struct block_device *bd_old,
  *
  * This function scans block devices and checks their sysfs path
  * to find any which contains PCI address specified for device in path.
+ * The character after the sub_path match is required to be one of the
+ * following ('\n', '\0', '/'), otherwise it is excluded.
  *
  * @param[in]        sub_path        Sub path.
  *

--- a/src/cntrl.c
+++ b/src/cntrl.c
@@ -56,11 +56,9 @@ static const char * const ctrl_type_str[] = {
 	[CNTRL_TYPE_AMD]     = "AMD",
 };
 
-#define CTRL_TYPE_STR_NUM (sizeof(ctrl_type_str)/sizeof(ctrl_type_str[0]))
-
 enum cntrl_type string_to_cntrl_type(const char *cntrl_str)
 {
-	for(int i = 0; i < CTRL_TYPE_STR_NUM; i++) {
+	for(int i = 0; i < ARRAY_SIZE(ctrl_type_str); i++) {
 		if (strcasecmp(cntrl_str, ctrl_type_str[i]) == 0 ) {
 			return (enum cntrl_type)i;
 		}

--- a/src/cntrl.c
+++ b/src/cntrl.c
@@ -56,6 +56,23 @@ static const char * const ctrl_type_str[] = {
 	[CNTRL_TYPE_AMD]     = "AMD",
 };
 
+#define CTRL_TYPE_STR_NUM (sizeof(ctrl_type_str)/sizeof(ctrl_type_str[0]))
+
+enum cntrl_type string_to_cntrl_type(const char *cntrl_str)
+{
+	for(int i = 0; i < CTRL_TYPE_STR_NUM; i++) {
+		if (strcasecmp(cntrl_str, ctrl_type_str[i]) == 0 ) {
+			return (enum cntrl_type)i;
+		}
+	}
+	return CNTRL_TYPE_UNKNOWN;
+}
+
+const char * const cntrl_type_to_string(enum cntrl_type cntrl)
+{
+	return ctrl_type_str[cntrl];
+}
+
 /**
  */
 static int _is_storage_controller(const char *path)

--- a/src/cntrl.h
+++ b/src/cntrl.h
@@ -36,6 +36,23 @@ enum cntrl_type {
 	CNTRL_TYPE_AMD,
 };
 
+
+/**
+ * @brief Translates string to controller enumerated type
+ *
+ * @param cntrl_str          string to translate
+ * @return enum cntrl_type   enumerated value
+ */
+enum cntrl_type string_to_cntrl_type(const char *cntrl_str);
+
+/**
+ * @brief Translates enumerated type to string representation
+ *
+ * @param cntrl               Enumerated type to translate to string representation
+ * @return const char* const  String representation of enumerated type
+ */
+const char *const cntrl_type_to_string(enum cntrl_type cntrl);
+
 /**
  * @brief Storage controller device structure.
  *

--- a/src/enclosure.c
+++ b/src/enclosure.c
@@ -226,7 +226,7 @@ static status_t _enclosure_get_slot(struct enclosure_device *encl, int index, st
 	return STATUS_SUCCESS;
 }
 
-static status_t parse_slot_num(char *slot_num, char *enclosure_id, int *index)
+static status_t parse_slot_id(char *slot_num, char *enclosure_id, int *index)
 {
 	char tmp_enclosure_id[PATH_MAX];
 	const char *index_str;
@@ -253,7 +253,7 @@ static status_t enclosure_get_slot_by_slot_num(char *slot_num, struct slot_respo
 	int index = -1;
 	struct enclosure_device *encl = NULL;
 
-	status_t parse = parse_slot_num(slot_num, enclosure_id, &index);
+	status_t parse = parse_slot_id(slot_num, enclosure_id, &index);
 	if (STATUS_SUCCESS != parse)
 		return parse;
 
@@ -294,7 +294,7 @@ status_t enclosure_set_slot(char *slot_num, enum ibpi_pattern state)
 	struct enclosure_device *enclosure_device;
 	char enclosure_id[PATH_MAX];
 
-	status_t parse = parse = parse_slot_num(slot_num, enclosure_id, &index);
+	status_t parse = parse_slot_id(slot_num, enclosure_id, &index);
 	if (STATUS_SUCCESS != parse)
 		return parse;
 

--- a/src/enclosure.c
+++ b/src/enclosure.c
@@ -208,7 +208,7 @@ static struct ses_slot *find_enclosure_slot_by_index(struct enclosure_device *en
 }
 
 static status_t _enclosure_get_slot(struct enclosure_device *encl, int index,
-									const char *device, struct slot_response *slot_res)
+					const char *device, struct slot_response *slot_res)
 {
 	struct block_device *block_device = NULL;
 	struct ses_slot *s_slot = find_enclosure_slot_by_index(encl, index);
@@ -276,6 +276,7 @@ static status_t enclosure_get_slot_by_slot_num(char *slot_num, struct slot_respo
 
 static status_t enclosure_get_slot_by_device(char *device, struct slot_response *slot_res)
 {
+	char device_node[PATH_MAX] = {0,};
 	struct block_device *block_device = get_block_device_from_sysfs_path(basename(device));
 
 	if (!block_device) {
@@ -287,7 +288,9 @@ static status_t enclosure_get_slot_by_device(char *device, struct slot_response 
 		log_error("SCSI: Not a SCSI ses device %n\n", device);
 		return STATUS_INVALID_PATH;
 	}
-	return _enclosure_get_slot(block_device->enclosure, block_device->encl_index, device, slot_res);
+
+	snprintf(device_node, PATH_MAX, "/dev/%s", basename(block_device->sysfs_path));
+	return _enclosure_get_slot(block_device->enclosure, block_device->encl_index, device_node, slot_res);
 }
 
 status_t enclosure_get_slot(char *device, char *slot_num, struct slot_response *slot_res)

--- a/src/enclosure.h
+++ b/src/enclosure.h
@@ -25,6 +25,8 @@
 #include <limits.h>
 
 #include "ses.h"
+#include "slot.h"
+#include "status.h"
 
 /**
  * @brief Enclosure device structure.
@@ -84,5 +86,32 @@ struct enclosure_device *enclosure_device_init(const char *path);
 void enclosure_device_fini(struct enclosure_device *enclosure);
 
 int enclosure_open(const struct enclosure_device *enclosure);
+
+/**
+ * @brief Gets led state for slot.
+ *
+ * This function finds slot connected to given identifier
+ * and fills slot response related to the slot.
+ *
+ * @param[in]         device         Requested device name.
+ * @param[in]         slot_num       Requested identifier of the slot.
+ * @param[in]         slot_res       Pointer to the slot response.
+ *
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
+ */
+status_t enclosure_get_slot(char *device, char *slot_num, struct slot_response *slot_res);
+
+/**
+ * @brief Sets led state for slot.
+ *
+ * This function finds slot connected to given number or device name
+ * and set given led state.
+ *
+ * @param[in]         slot_num       Requested number of the slot.
+ * @param[in]         state          IBPI state based on slot request.
+ *
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
+ */
+status_t enclosure_set_slot(char *slot_num, enum ibpi_pattern state);
 
 #endif				/* _ENCLOSURE_H_INCLUDED_ */

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -758,7 +758,7 @@ static ledctl_status_code_t slot_verify_request(struct slot_request *slot_req)
 		return LEDCTL_STATUS_INVALID_STATE;
 	}
 	if (!slot_req->get_slot_fn && !slot_req->set_slot_fn) {
-		log_error("The controller type %s doesn't support slot functionality.",
+		log_error("The controller type %d doesn't support slot functionality.",
 			  slot_req->cntrl);
 		return LEDCTL_STATUS_INVALID_CONTROLLER;
 	}

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -234,9 +234,7 @@ static int possible_params[] = {
 	OPT_LOG_LEVEL,
 };
 
-static const int possible_params_size = sizeof(possible_params)
-		/ sizeof(possible_params[0]);
-
+static const int possible_params_size = ARRAY_SIZE(possible_params);
 static int listed_only;
 
 /**

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -754,8 +754,8 @@ static ledctl_status_code_t slot_verify_request(struct slot_request *slot_req)
 		return LEDCTL_STATUS_INVALID_STATE;
 	}
 	if (!slot_req->get_slot_fn && !slot_req->set_slot_fn) {
-		log_error("The controller type %d doesn't support slot functionality.",
-			  slot_req->cntrl);
+		log_error("The controller type %s doesn't support slot functionality.",
+			cntrl_type_to_string(slot_req->cntrl));
 		return LEDCTL_STATUS_INVALID_CONTROLLER;
 	}
 	if (slot_req->device[0] && slot_req->slot[0]) {

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -841,13 +841,13 @@ ledctl_status_code_t slot_execute(struct slot_request *slot_req)
 		return list_slots(slot_req);
 	case OPT_SET_SLOT:
 		status = slot_req->get_slot_fn(slot_req->device, slot_req->slot, &slot_res);
+		if (status != LEDCTL_STATUS_SUCCESS)
+			return status;
 		if (slot_res.state == slot_req->state) {
 			log_warning("Led state: %s is already set for the slot.",
 				    ibpi2str(slot_req->state));
 			return LEDCTL_STATUS_SUCCESS;
 		}
-		if (status != LEDCTL_STATUS_SUCCESS)
-			return status;
 		status = slot_req->set_slot_fn(slot_res.slot, slot_req->state);
 		if (status != LEDCTL_STATUS_SUCCESS)
 			return status;

--- a/src/ledmon.c
+++ b/src/ledmon.c
@@ -144,8 +144,7 @@ static int possible_params[] = {
 	OPT_FOREGROUND,
 };
 
-static int possible_params_size = sizeof(possible_params)
-		/ sizeof(possible_params[0]);
+static int possible_params_size = ARRAY_SIZE(possible_params);
 
 /**
  * @brief Monitor service finalize function.

--- a/src/npem.c
+++ b/src/npem.c
@@ -314,7 +314,7 @@ status_t npem_get_slot(char *device, char *slot_path, struct slot_response *slot
 
 	reg = read_npem_register(pdev, PCI_NPEM_CTRL_REG);
 	slot_res->state = npem_capability_to_ibpi(reg);
-	snprintf(slot_res->slot, PATH_MAX, "%s", path);
+	snprintf(slot_res->slot, PATH_MAX, "%s", basename(path));
 
 	if (block_device)
 		snprintf(slot_res->device, PATH_MAX, "/dev/%s", basename(block_device->sysfs_path));

--- a/src/scsi.h
+++ b/src/scsi.h
@@ -69,4 +69,39 @@ int scsi_ses_flush(struct block_device *device);
  * */
 int scsi_get_enclosure(struct block_device *device);
 
+/**
+ * @brief Locates a block device by sas_address
+ *
+ * This function walks the list of block devices searching for one that
+ * matches the sas_address.
+ * @param[in]       sas_address   sas address of block device
+ *
+ * @return address of block_device if found, else NULL
+ */
+struct block_device *locate_block_by_sas_addr(uint64_t sas_address);
+
+/**
+ * @brief Given an enclosure_device pointer and slot index, prepare the SES message
+ *
+ * @param[in]      enclosure      Enclosure
+ * @param[in]      idx            slot in enclosure
+ * @param[in]      ibpi           IBPI pattern to visualize.
+ *
+ * @return 0 on success, otherwise error.
+ */
+int scsi_ses_write_enclosure(struct enclosure_device *enclosure, int idx, enum ibpi_pattern ibpi);
+
+/**
+ * @brief Sends message to SES processor of an enclosure.
+ *
+ * This function sends a message to an enclosure in order to control LEDs of
+ * the given slot/component. It uses the interface of ENCLOSURE kernel module to
+ * control LEDs.
+ *
+ * @param[in]      enclosure       Pointer to enclosure to flush
+ *
+ * @return 0 on success, otherwise error.
+ */
+int scsi_ses_flush_enclosure(struct enclosure_device *enclosure);
+
 #endif				/* _SCSI_H_INCLUDED_ */

--- a/src/ses.c
+++ b/src/ses.c
@@ -487,14 +487,6 @@ int ses_get_slots(struct ses_pages *sp, struct ses_slot **out_slots, int *out_sl
 	unsigned char *ap = NULL, *addr_p = NULL;
 	int i, j, len = 0;
 
-	// Our expectation is that the caller is passing us NULL or a valid chunk of memory for
-	// slots that was used before and are now reloading, so free it first.
-	if (*out_slots) {
-		free(*out_slots);
-		*out_slots = NULL;
-	}
-	*out_slots_count = 0;
-
 	/* Check Page10 for address. Extract index. */
 	ap = add_desc = sp->page10.buf + 8;
 	for (i = 0; i < sp->page1_types_len; i++) {
@@ -538,6 +530,9 @@ int ses_get_slots(struct ses_pages *sp, struct ses_slot **out_slots, int *out_sl
 				get_led_status(sp, slots[j].index, &slots[j].ibpi_status);
 			}
 
+			// Our expectation is that the caller is passing us NULL or a valid chunk of
+			// memory for slots that was used before and are now reloading, so free it first.
+			free(*out_slots);
 			*out_slots = slots;
 			*out_slots_count = t->num_of_elements;
 

--- a/src/ses.h
+++ b/src/ses.h
@@ -70,6 +70,7 @@ struct ses_slot_ctrl_elem {
 struct ses_slot {
 	int index;
 	uint64_t sas_addr;
+	enum ibpi_pattern ibpi_status;
 };
 
 int ses_load_pages(int fd, struct ses_pages *sp);

--- a/src/slot.h
+++ b/src/slot.h
@@ -57,7 +57,7 @@ struct slot_response {
 static inline void print_slot_state(struct slot_response *res)
 {
 	printf("slot: %-15s led state: %-15s device: %-15s\n",
-	       basename(res->slot), ibpi2str(res->state), res->device);
+		res->slot, ibpi2str(res->state), res->device);
 }
 
 #endif // SLOT_H_INCLUDED_

--- a/src/utils.h
+++ b/src/utils.h
@@ -62,6 +62,11 @@ char *str_map(int scode, struct map *map);
 #define WRITE_BUFFER_SIZE   1024
 
 /**
+ * @brief Macro for compile time array size constants
+ */
+#define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
+
+/**
  * This structure describes a device identifier. It consists of major and minor
  * attributes of device.
  */


### PR DESCRIPTION
~~This PR is a work in progress, posting early to get some feedback before I spend more time on it~~.  I've found some minor issues when working on this change which are included at the beginning of the change set.  However, in my test environment I'm finding it functional.

Some open questions and areas that need a bit of work:
1. When a SES slot has both the locate and fail LEDs illuminated, what is the IBPI pattern?
2. I'm thinking the code added to retrieve the LED status is not totally correct, need to read more SES documentation.
3. I have an enclosure that I believe doesn't have any trays (system is sitting in a remote lab).  `sg_ses` reports a check condition when I try to get/set a slot, ledctl operates like it was successful.  I need to dig into this.
4. I believe it would be beneficial if the slot specifier was persistent, that it would survive reboots and dynamic reconfiguration.  I believe this could be attained with SES by using an identifier in the enclosure that persists?
5. ledctl has no knowledge of multi-path, thus if you don't specify `-x` when doing something like `./ledctl locate=/dev/sdk` the code clears LEDs of every device twice.  I'll write up an issue on this.

Sample output of two of the enclosures I have attached to a test system.
```
  # ./ledctl --list-slots --controller SCSI 
/dev/shm/ledmon.conf: does not exist, using global config file
/etc/ledmon.conf: does not exist, using built-in defaults
slot: /dev/sg43/0     led state: LOCATE          device: /dev/sdw       
slot: /dev/sg43/1     led state: FAILURE         device: /dev/sdx       
slot: /dev/sg43/2     led state: NORMAL          device: /dev/sdy       
slot: /dev/sg43/3     led state: NORMAL          device: /dev/sdz       
slot: /dev/sg43/4     led state: LOCATE          device: /dev/sdaa      
slot: /dev/sg43/5     led state: NORMAL          device: /dev/sdab      
slot: /dev/sg43/6     led state: NORMAL          device: /dev/sdac      
slot: /dev/sg43/7     led state: NORMAL          device: /dev/sdad      
slot: /dev/sg43/8     led state: NORMAL          device: /dev/sdae      
slot: /dev/sg43/9     led state: NORMAL          device: /dev/sdaf      
slot: /dev/sg43/10    led state: NORMAL          device: /dev/sdag      
slot: /dev/sg43/11    led state: NORMAL          device: /dev/sdah      
slot: /dev/sg43/12    led state: NORMAL          device: /dev/sdai      
slot: /dev/sg43/13    led state: NORMAL          device: /dev/sdaj      
slot: /dev/sg43/14    led state: NORMAL          device: /dev/sdak      
slot: /dev/sg43/15    led state: NORMAL          device: /dev/sdal      
slot: /dev/sg48/0     led state: NORMAL          device: /dev/sdam      
slot: /dev/sg48/1     led state: NORMAL          device: /dev/sdan      
slot: /dev/sg48/2     led state: NORMAL          device:                
slot: /dev/sg48/3     led state: NORMAL          device:                
slot: /dev/sg48/4     led state: NORMAL          device:                
slot: /dev/sg48/5     led state: NORMAL          device:                
slot: /dev/sg48/6     led state: FAILURE         device:                
slot: /dev/sg48/7     led state: LOCATE          device:                
slot: /dev/sg48/8     led state: NORMAL          device:                
slot: /dev/sg48/9     led state: NORMAL          device:                
slot: /dev/sg48/10    led state: NORMAL          device:                
slot: /dev/sg48/11    led state: NORMAL          device:                
slot: /dev/sg48/12    led state: NORMAL          device: /dev/sdao      
slot: /dev/sg48/13    led state: NORMAL          device: /dev/sdap      
slot: /dev/sg48/14    led state: NORMAL          device:                
slot: /dev/sg48/15    led state: NORMAL          device:                     
...
```