### PR TITLE
npem, vmd: fix ibpi_value lists getter.

### DIFF
--- a/src/pci_slot.c
+++ b/src/pci_slot.c
@@ -98,13 +98,10 @@ static status_t set_slot_response(struct pci_slot *slot, struct slot_response *s
 {
 	struct block_device *bl_device;
 	status_t status = STATUS_SUCCESS;
-	int attention = get_int(slot->sysfs_path, -1, "attention");
 
-	if (attention == -1)
-		return STATUS_INVALID_STATE;
-
-	slot_res->state = get_ibpi_for_value(attention, ibpi_to_attention);
 	snprintf(slot_res->slot, PATH_MAX, "%s", basename(slot->sysfs_path));
+
+	slot_res->state = vmdssd_get_attention(slot);
 
 	bl_device = get_block_device_from_sysfs_path(slot->address);
 	if (bl_device)

--- a/src/utils.c
+++ b/src/utils.c
@@ -27,6 +27,7 @@
 #include <limits.h>
 #include <regex.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -708,46 +709,55 @@ const char *ibpi2str(enum ibpi_pattern ibpi)
 	return ret;
 }
 
-/**
- * @brief Returns value based on IBPI state
- *
- * @param[in]       value       Value for led state.
- * @param[in]       ibpi_values    Array with defined IBPI states and values.
- *
- * @return Integer value which represents given IBPI state.
- */
-int get_value_for_ibpi(enum ibpi_pattern ibpi, const struct ibpi_value ibpi_values[])
+static const struct ibpi2value *get_ibpi_value(const unsigned int val,
+					       const struct ibpi2value *ibpi2val_arr,
+					       const int ibpi2value_arr_cnt,
+					       bool (*compar)(const unsigned int val,
+							      const struct ibpi2value *ibpi2val))
 {
-	const struct ibpi_value *tmp = ibpi_values;
+	int cnt = 0;
+	const struct ibpi2value *tmp = NULL;
 
-	while (tmp->ibpi != IBPI_PATTERN_UNKNOWN) {
-		if (tmp->ibpi == ibpi)
-			break;
-		tmp++;
-	}
-	return tmp->value;
+	do {
+		/* Prevent out of bound results */
+		assert(cnt < ibpi2value_arr_cnt);
+
+		tmp = ibpi2val_arr + cnt;
+		if (compar(val, tmp))
+			return tmp;
+		cnt++;
+	} while (tmp->ibpi != IBPI_PATTERN_UNKNOWN);
+
+	return tmp;
 }
 
-/**
- * @brief Returns IBPI pattern based on value
- *
- * @param[in]       value          Value for led state.
- * @param[in]       ibpi_values    Array with defined IBPI states and values.
- *
- * @return Enum with IBPI value, which represents given value.
- */
-enum ibpi_pattern get_ibpi_for_value(const int value, const struct ibpi_value ibpi_values[])
+static bool compar_bits(const unsigned int val, const struct ibpi2value *ibpi2val)
 {
-	const struct ibpi_value *tmp = ibpi_values;
-
-	while (tmp->ibpi != IBPI_PATTERN_UNKNOWN) {
-		if (tmp->value == value)
-			break;
-		tmp++;
-	}
-	return tmp->ibpi;
+	if (ibpi2val->value & val)
+		return true;
+	return false;
 }
 
+#define IBPI2VALUE_GET_FN(_name)							\
+const struct ibpi2value *get_by_##_name(const enum ibpi_pattern ibpi,			\
+				     const struct ibpi2value *ibpi2val_arr,		\
+				     int ibpi2value_arr_cnt)				\
+{											\
+	return get_ibpi_value(ibpi, ibpi2val_arr, ibpi2value_arr_cnt, compar_##_name);	\
+}
+
+#define COMPARE(_name)									\
+static bool compar_##_name(const unsigned int val, const struct ibpi2value *ibpi2val)	\
+{											\
+	if (ibpi2val->_name == val)							\
+		return true;								\
+	return false;									\
+}											\
+IBPI2VALUE_GET_FN(_name)								\
+
+IBPI2VALUE_GET_FN(bits);
+COMPARE(ibpi);
+COMPARE(value);
 /**
  * @brief Get string from map.
  *

--- a/src/utils.c
+++ b/src/utils.c
@@ -709,7 +709,7 @@ const char *ibpi2str(enum ibpi_pattern ibpi)
 	return ret;
 }
 
-static const struct ibpi2value *get_ibpi_value(const unsigned int val,
+static const struct ibpi2value *get_ibpi2value(const unsigned int val,
 					       const struct ibpi2value *ibpi2val_arr,
 					       const int ibpi2value_arr_cnt,
 					       bool (*compar)(const unsigned int val,
@@ -740,10 +740,10 @@ static bool compar_bits(const unsigned int val, const struct ibpi2value *ibpi2va
 
 #define IBPI2VALUE_GET_FN(_name)							\
 const struct ibpi2value *get_by_##_name(const enum ibpi_pattern ibpi,			\
-				     const struct ibpi2value *ibpi2val_arr,		\
-				     int ibpi2value_arr_cnt)				\
+					const struct ibpi2value *ibpi2val_arr,		\
+					int ibpi2value_arr_cnt)				\
 {											\
-	return get_ibpi_value(ibpi, ibpi2val_arr, ibpi2value_arr_cnt, compar_##_name);	\
+	return get_ibpi2value(ibpi, ibpi2val_arr, ibpi2value_arr_cnt, compar_##_name);	\
 }
 
 #define COMPARE(_name)									\

--- a/src/utils.h
+++ b/src/utils.h
@@ -79,8 +79,12 @@ struct log_level_info {
 	int priority;
 };
 
-struct ibpi_value {
-	int ibpi, value;
+/**
+ * @brief The struct is used for mapping IPBI pattern to the controller internal value.
+ */
+struct ibpi2value {
+	unsigned int ibpi;
+	unsigned int value;
 };
 
 /**
@@ -459,7 +463,44 @@ int get_option_id(const char *optarg);
 status_t set_verbose_level(int log_level);
 
 const char *ibpi2str(enum ibpi_pattern ibpi);
-int get_value_for_ibpi(enum ibpi_pattern ibpi, const struct ibpi_value ibpi_values[]);
-enum ibpi_pattern get_ibpi_for_value(const int value, const struct ibpi_value ibpi_values[]);
+
+/**
+ * @brief Returns ibpi2value entry if IBPI matches
+ *
+ * @param[in]       ibpi                  IBPI pattern.
+ * @param[in]       ibpi2val_arr          IBPI pattern to value array.
+ * @param[in]       ibpi2value_arr_cnt    Array entries count.
+ *
+ * @return Corresponding ibpi2value entry last or entry with IBPI_PATTERN_UNKNOWN
+ */
+const struct ibpi2value *get_by_ibpi(const enum ibpi_pattern ibpi,
+				     const struct ibpi2value *ibpi2val_arr,
+				     int ibpi2value_arr_cnt);
+
+/**
+ * @brief Returns ibpi2value entry if value matches
+ *
+ * @param[in]       value                 value to compare.
+ * @param[in]       ibpi2val_arr          IBPI pattern to value array.
+ * @param[in]       ibpi2value_arr_cnt    Array entries count.
+ *
+ * @return Corresponding ibpi2value entry last or entry with IBPI_PATTERN_UNKNOWN
+ */
+const struct ibpi2value *get_by_value(const unsigned int value,
+				      const struct ibpi2value *ibpi2val_arr,
+				      int ibpi2value_arr_cnt);
+
+/**
+ * @brief Returns ibpi2value entry if any bit matches
+ *
+ * @param[in]       value                 value to compare.
+ * @param[in]       ibpi2val_arr          IBPI pattern to value array.
+ * @param[in]       ibpi2value_arr_cnt    Array entries count.
+ *
+ * @return Corresponding ibpi2value entry last or entry with IBPI_PATTERN_UNKNOWN
+ */
+const struct ibpi2value *get_by_bits(const unsigned int value,
+				     const struct ibpi2value *ibpi2val_arr,
+				     int ibpi2value_arr_cnt);
 
 #endif				/* _UTILS_H_INCLUDED_ */

--- a/src/vmdssd.h
+++ b/src/vmdssd.h
@@ -30,11 +30,10 @@
 #define ATTENTION_REBUILD    0x5  /* (0101) Attention On, Power On */
 #define ATTENTION_FAILURE    0xD  /* (1101) Attention On, Power Off */
 
-extern struct ibpi_value ibpi_to_attention[];
-
 int vmdssd_write(struct block_device *device, enum ibpi_pattern ibpi);
 char *vmdssd_get_path(const char *cntrl_path);
 struct pci_slot *vmdssd_find_pci_slot(char *device_path);
 status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum ibpi_pattern ibpi);
+enum ibpi_pattern vmdssd_get_attention(struct pci_slot *slot);
 
 #endif


### PR DESCRIPTION
The last element on list must be IBPI_PATTERN_UNKNOWN, otherwise we can read out of bound memory. It is possible now when not supported pattern is requested with --set-slot for VMD. In my case it doesn't produce issue because it reads zeros from memory after the array. Fix that for vmd controller by adding IBPI_PATTERN_UNKNOWN element to array with no value. Add validation of returned value where necessary.

To avoid such issues appropriative assert is added.

List of changes:
- Rename ibpi_value to ibpi2value to make it more meaningful.
- Change both ibpi and value to unsigned. Enum is started from 0 so it is safe.
- Return ibpi2value struct instead of raw enum/value.
- Create one get_ibpi_value() function.
- Pass size to get_ibpi_value() and add assert.
- Move attention_get to vmdssd to avoid extern ibpi_to_attention[].
- Generate compar* functions.
- fix for set_slot_npem in get_pci_dev(), use basename().
- Update descriptions.
- Use ibpi2value in amd_ipmi
- Use ibpi2value in ahci
- Use ibpi2value in dellssd

Now caller can verify what was returned and react accordingly if needed.

Signed-off-by: Mariusz Tkaczyk <mariusz.tkaczyk@linux.intel.com>