### PR TITLE
Remove exclusionary language

### DIFF
--- a/doc/ledmon.conf.pod
+++ b/doc/ledmon.conf.pod
@@ -42,10 +42,12 @@ See also the examples section.
 
 =head2 List of configurable options:
 
-B<BLACKLIST> - Ledmon will exclude scanning controllers listed on blacklist.
-When whitelist is also set in config file, the blacklist will be ignored.
+B<EXCLUDELIST> - Ledmon will exclude scanning controllers listed on excludelist.
+When allowlist is also set in config file, the excludelist will be ignored.
 The controllers should be separated by comma (B<,>) character.
-The B<XBD Extended Regular Expressions> are supported.
+The B<XBD Extended Regular Expressions> are supported.  The deprecated name of
+B<BLACKLIST> is supported for backwards compatibility.  It will be
+removed in a future release.
 
 B<BLINK_ON_INIT> - Related with RAID Initialization (resync), Verify (check)
 and Verify and Fix (repair) processes. If value is set to true - status LEDs of
@@ -80,10 +82,12 @@ is set to false - only the drive that the RAID is rebuilding to will be marked
 with appropriate LED pattern. If value is set to true all drives from RAID
 that is during rebuild will blink during this operation.
 
-B<WHITELIST> - Ledmon will limit changing LED state to controllers listed on
-whitelist. If any whitelist is set, only devices from list will be scanned by
+B<ALLOWLIST> - Ledmon will limit changing LED state to controllers listed on
+allowlist. If any allowlist is set, only devices from list will be scanned by
 ledmon. The controllers should be separated by comma (B<,>) character.
-The B<XBD Extended Regular Expressions> are supported.
+The B<XBD Extended Regular Expressions> are supported.  The deprecated name of
+B<WHITELIST> is supported for backwards compatibility.  It will be
+removed in a future release.
 
 =head1 EXAMPLES
 
@@ -96,7 +100,7 @@ INTERVAL=5
 
 #Exclude disks from SATA controller
 
-BLACKLIST=/sys/devices/pci0000:00/0000:00:17.0
+EXCLUDELIST=/sys/devices/pci0000:00/0000:00:17.0
 
 =head2 Blink only on RAID members, blink on all disks during rebuild and ignore
 init phase:

--- a/src/cntrl.c
+++ b/src/cntrl.c
@@ -413,24 +413,24 @@ struct cntrl_device *cntrl_device_init(const char *path)
 
 	type = _get_type(path);
 	if (type != CNTRL_TYPE_UNKNOWN) {
-		if (!list_is_empty(&conf.cntrls_whitelist)) {
+		if (!list_is_empty(&conf.cntrls_allowlist)) {
 			char *cntrl = NULL;
 
-			list_for_each(&conf.cntrls_whitelist, cntrl) {
+			list_for_each(&conf.cntrls_allowlist, cntrl) {
 				if (match_string(cntrl, path))
 					break;
 				cntrl = NULL;
 			}
 			if (!cntrl) {
-				log_debug("%s not found on whitelist, ignoring", path);
+				log_debug("%s not found on allowlist, ignoring", path);
 				return NULL;
 			}
-		} else if (!list_is_empty(&conf.cntrls_blacklist)) {
+		} else if (!list_is_empty(&conf.cntrls_excludelist)) {
 			char *cntrl;
 
-			list_for_each(&conf.cntrls_blacklist, cntrl) {
+			list_for_each(&conf.cntrls_excludelist, cntrl) {
 				if (match_string(cntrl, path)) {
-					log_debug("%s found on blacklist, ignoring",
+					log_debug("%s found on excludelist, ignoring",
 						  path);
 					return NULL;
 				}

--- a/src/config_file.h
+++ b/src/config_file.h
@@ -44,9 +44,9 @@ struct ledmon_conf {
 	int rebuild_blink_on_all;
 	int raid_members_only;
 
-	/* whitelist and blacklist of controllers for blinking */
-	struct list cntrls_whitelist;
-	struct list cntrls_blacklist;
+	/* allowlist and excludelist of controllers for blinking */
+	struct list cntrls_allowlist;
+	struct list cntrls_excludelist;
 };
 
 extern struct ledmon_conf conf;

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -1034,8 +1034,8 @@ static void _unset_unused_options(void)
 {
 	conf.blink_on_init = false;
 	conf.blink_on_migration = false;
-	list_erase(&conf.cntrls_blacklist);
-	list_erase(&conf.cntrls_whitelist);
+	list_erase(&conf.cntrls_excludelist);
+	list_erase(&conf.cntrls_allowlist);
 	conf.raid_members_only = false;
 	conf.rebuild_blink_on_all = false;
 	conf.scan_interval = 0;
@@ -1046,8 +1046,8 @@ static ledctl_status_code_t _init_ledctl_conf(void)
 	memset(&conf, 0, sizeof(struct ledmon_conf));
 	/* initialize with default values */
 	conf.log_level = LOG_LEVEL_WARNING;
-	list_init(&conf.cntrls_whitelist, NULL);
-	list_init(&conf.cntrls_blacklist, NULL);
+	list_init(&conf.cntrls_allowlist, NULL);
+	list_init(&conf.cntrls_excludelist, NULL);
 
 	return set_log_path(LEDCTL_DEF_LOG_FILE);
 }

--- a/src/ledmon.c
+++ b/src/ledmon.c
@@ -860,8 +860,8 @@ static ledmon_status_code_t _init_ledmon_conf(void)
 	conf.raid_members_only = 0;
 	conf.log_level = LOG_LEVEL_WARNING;
 	conf.scan_interval = LEDMON_DEF_SLEEP_INTERVAL;
-	list_init(&conf.cntrls_whitelist, NULL);
-	list_init(&conf.cntrls_blacklist, NULL);
+	list_init(&conf.cntrls_allowlist, NULL);
+	list_init(&conf.cntrls_excludelist, NULL);
 	return set_log_path(LEDMON_DEF_LOG_FILE);
 }
 


### PR DESCRIPTION
Note: Still supports exclusionary language for existing configuration files, to ensure backwards compatibility.  In the future this should be removed.

Signed-off-by: Tony Asleson <tasleson@redhat.com>