### PR TITLE
amd_ipmi: Allow to _enable_smbus_control

### DIFF
--- a/src/amd_ipmi.c
+++ b/src/amd_ipmi.c
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 #include <unistd.h>
 #include <libgen.h>
@@ -272,23 +273,13 @@ static int _ipmi_platform_slave_address(struct amd_drive *drive)
 	return rc;
 }
 
-static int _set_ipmi_register(int enable, enum ibpi_pattern ibpi, struct amd_drive *drive)
+static int _set_ipmi_register(int enable, uint8_t reg, struct amd_drive *drive)
 {
 	int rc;
 	int status, data_sz;
 	uint8_t drives_status;
 	uint8_t new_drives_status;
 	uint8_t cmd_data[5];
-	uint8_t reg;
-
-	const struct ibpi2value *ibpi2val = get_by_ibpi(ibpi, ibpi2amd_ipmi,
-							ARRAY_SIZE(ibpi2amd_ipmi));
-
-	if (ibpi2val->ibpi == IBPI_PATTERN_UNKNOWN) {
-		log_error("AMD_APMI: Controller doesn't support %s pattern\n", ibpi_str[ibpi]);
-		return STATUS_INVALID_STATE;
-	}
-	reg = (uint8_t)ibpi2val->value;
 
 	memset(cmd_data, 0, sizeof(cmd_data));
 
@@ -350,27 +341,33 @@ static int _enable_smbus_control(struct amd_drive *drive)
 	return _set_ipmi_register(1, 0x3c, drive);
 }
 
-static int _enable_ibpi_state(struct amd_drive *drive, enum ibpi_pattern ibpi)
+static int _change_ibpi_state(struct amd_drive *drive, enum ibpi_pattern ibpi, bool enable)
 {
-	log_debug("Enabling %s LED\n", ibpi2str(ibpi));
-	return _set_ipmi_register(1, ibpi, drive);
-}
+	const struct ibpi2value *ibpi2val = get_by_ibpi(ibpi, ibpi2amd_ipmi,
+							ARRAY_SIZE(ibpi2amd_ipmi));
 
-static int _disable_ibpi_state(struct amd_drive *drive, enum ibpi_pattern ibpi)
-{
-	log_debug("Disabling %s LED\n", ibpi2str(ibpi));
-	return _set_ipmi_register(0, ibpi, drive);
+	if (ibpi2val->ibpi == IBPI_PATTERN_UNKNOWN) {
+		log_error("AMD_IPMI: Controller doesn't support %s pattern\n", ibpi_str[ibpi]);
+		return STATUS_INVALID_STATE;
+	}
+
+	if (enable)
+		log_debug("Enabling %s LED\n", ibpi2str(ibpi));
+	else
+		log_debug("Disabling %s LED\n", ibpi2str(ibpi));
+
+	return _set_ipmi_register(enable, ibpi2val->value, drive);
 }
 
 static int _disable_all_ibpi_states(struct amd_drive *drive)
 {
 	int rc;
 
-	rc = _disable_ibpi_state(drive, IBPI_PATTERN_PFA);
-	rc |= _disable_ibpi_state(drive, IBPI_PATTERN_LOCATE);
-	rc |= _disable_ibpi_state(drive, IBPI_PATTERN_FAILED_DRIVE);
-	rc |= _disable_ibpi_state(drive, IBPI_PATTERN_FAILED_ARRAY);
-	rc |= _disable_ibpi_state(drive, IBPI_PATTERN_REBUILD);
+	rc = _change_ibpi_state(drive, IBPI_PATTERN_PFA, false);
+	rc |= _change_ibpi_state(drive, IBPI_PATTERN_LOCATE, false);
+	rc |= _change_ibpi_state(drive, IBPI_PATTERN_FAILED_DRIVE, false);
+	rc |= _change_ibpi_state(drive, IBPI_PATTERN_FAILED_ARRAY, false);
+	rc |= _change_ibpi_state(drive, IBPI_PATTERN_REBUILD, false);
 
 	return rc;
 }
@@ -431,7 +428,7 @@ int _amd_ipmi_write(struct block_device *device, enum ibpi_pattern ibpi)
 	}
 
 	if (ibpi == IBPI_PATTERN_LOCATE_OFF) {
-		rc = _disable_ibpi_state(&drive, IBPI_PATTERN_LOCATE);
+		rc = _change_ibpi_state(&drive, IBPI_PATTERN_LOCATE, false);
 		return rc;
 	}
 
@@ -439,7 +436,7 @@ int _amd_ipmi_write(struct block_device *device, enum ibpi_pattern ibpi)
 	if (rc)
 		return rc;
 
-	rc = _enable_ibpi_state(&drive, ibpi);
+	rc = _change_ibpi_state(&drive, ibpi, true);
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
Bug intrduced by #116. There is another call to _set_ipmi_register() with special value. Merge _enable and _disable ibpi_state to move ibpi2val verification up.

Change-Id: I36398353da6fee3947056c0beaf205d3bd8da082