### PR TITLE
sysfs: add only vmd devices to slots_list

### DIFF
--- a/src/cntrl.c
+++ b/src/cntrl.c
@@ -39,6 +39,7 @@
 #include "utils.h"
 #include "amd.h"
 #include "npem.h"
+#include "vmdssd.h"
 
 /**
  * @brief Name of controllers types.
@@ -462,6 +463,9 @@ struct cntrl_device *cntrl_device_init(const char *path)
 					device->isci_present = 0;
 					device->hosts = NULL;
 				}
+				if (type == CNTRL_TYPE_VMD)
+					snprintf(device->domain, PATH_MAX, "%s",
+						 vmdssd_get_domain(path));
 				device->cntrl_type = type;
 				strncpy(device->sysfs_path, path, PATH_MAX - 1);
 			}

--- a/src/cntrl.h
+++ b/src/cntrl.h
@@ -74,6 +74,11 @@ struct cntrl_device {
 	 */
 	int isci_present;
 
+	/**
+	 * Applicable to VMD controllers. Domain address.
+	 */
+	char domain[PATH_MAX];
+
 	struct _host_type {
 		/**
 		 * ibpi state buffer for directly attached devices

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -44,7 +44,6 @@
 #include "stdio.h"
 #include "sysfs.h"
 #include "utils.h"
-#include "vmdssd.h"
 
 /**
  */

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -455,7 +455,6 @@ static void _scan_enclo(void)
 static void _scan_slots(void)
 {
 	struct list dir;
-
 	if (scan_dir(SYSFS_PCI_SLOTS, &dir) == 0) {
 		const char *dir_path;
 

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -44,6 +44,7 @@
 #include "stdio.h"
 #include "sysfs.h"
 #include "utils.h"
+#include "vmdssd.h"
 
 /**
  */
@@ -454,11 +455,17 @@ static void _scan_enclo(void)
 static void _scan_slots(void)
 {
 	struct list dir;
+	char attention_path[PATH_MAX], temp[PATH_MAX];
+
 	if (scan_dir(SYSFS_PCI_SLOTS, &dir) == 0) {
 		const char *dir_path;
 
-		list_for_each(&dir, dir_path)
-			_slots_add(dir_path);
+		list_for_each(&dir, dir_path) {
+			snprintf(attention_path, PATH_MAX, "%s/%s", dir_path, "attention");
+			if (realpath(attention_path, temp) != NULL &&
+			    vmdssd_check_slot_module(dir_path) == 0)
+				_slots_add(dir_path);
+		}
 		list_erase(&dir);
 	}
 }

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -460,12 +460,8 @@ static void _scan_slots(void)
 	if (scan_dir(SYSFS_PCI_SLOTS, &dir) == 0) {
 		const char *dir_path;
 
-		list_for_each(&dir, dir_path) {
-			snprintf(attention_path, PATH_MAX, "%s/%s", dir_path, "attention");
-			if (realpath(attention_path, temp) != NULL &&
-			    vmdssd_check_slot_module(dir_path) == 0)
-				_slots_add(dir_path);
-		}
+		list_for_each(&dir, dir_path)
+			_slots_add(dir_path);
 		list_erase(&dir);
 	}
 }

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -455,7 +455,6 @@ static void _scan_enclo(void)
 static void _scan_slots(void)
 {
 	struct list dir;
-	char attention_path[PATH_MAX], temp[PATH_MAX];
 
 	if (scan_dir(SYSFS_PCI_SLOTS, &dir) == 0) {
 		const char *dir_path;

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -21,6 +21,7 @@
 
 #include <fcntl.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -44,6 +45,7 @@
 #include "stdio.h"
 #include "sysfs.h"
 #include "utils.h"
+#include "vmdssd.h"
 
 /**
  */
@@ -457,8 +459,10 @@ static void _scan_slots(void)
 	if (scan_dir(SYSFS_PCI_SLOTS, &dir) == 0) {
 		const char *dir_path;
 
-		list_for_each(&dir, dir_path)
-			_slots_add(dir_path);
+		list_for_each(&dir, dir_path) {
+			if (vmdssd_check_slot_module(dir_path) == true)
+				_slots_add(dir_path);
+		}
 		list_erase(&dir);
 	}
 }

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -71,7 +71,7 @@ static char *get_slot_from_syspath(char *path)
 	return ret;
 }
 
-static int check_slot_module(const char *slot_path)
+int vmdssd_check_slot_module(const char *slot_path)
 {
 	char module_path[PATH_MAX], real_module_path[PATH_MAX];
 	struct list dir;
@@ -106,7 +106,7 @@ struct pci_slot *vmdssd_find_pci_slot(char *device_path)
 		slot = NULL;
 	}
 	free(pci_addr);
-	if (slot == NULL || check_slot_module(slot->sysfs_path) < 0)
+	if (slot == NULL || vmdssd_check_slot_module(slot->sysfs_path) < 0)
 		return NULL;
 
 	return slot;

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -85,8 +85,13 @@ bool vmdssd_check_slot_module(const char *slot_path)
 				 SYSFS_VMD, basename(cntrl->sysfs_path));
 			if (realpath(domain_path, real_domain_path) == NULL)
 				return false;
+
 			address = get_text(slot_path, "address");
+			if (address == NULL)
+				return false;
 			domain = strtok(basename(real_domain_path), ":");
+			if (domain == NULL)
+				return false;
 
 			if (strstr(address, domain) == NULL)
 				continue;

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -72,7 +72,7 @@ static char *get_slot_from_syspath(char *path)
 	return ret;
 }
 
-int vmdssd_check_slot_module(const char *slot_path)
+bool vmdssd_check_slot_module(const char *slot_path)
 {
 	char domain_path[PATH_MAX], real_domain_path[PATH_MAX];
 	char *address, *domain;
@@ -84,17 +84,17 @@ int vmdssd_check_slot_module(const char *slot_path)
 			snprintf(domain_path, PATH_MAX, "%s/%s/domain",
 				 SYSFS_VMD, basename(cntrl->sysfs_path));
 			if (realpath(domain_path, real_domain_path) == NULL)
-				return -1;
+				return false;
 			address = get_text(slot_path, "address");
 			domain = strtok(basename(real_domain_path), ":");
 
 			if (strstr(address, domain) == NULL)
 				continue;
-			return 0;
+			return true;
 		}
 	}
 
-	return 0;
+	return false;
 }
 
 struct pci_slot *vmdssd_find_pci_slot(char *device_path)
@@ -112,7 +112,7 @@ struct pci_slot *vmdssd_find_pci_slot(char *device_path)
 		slot = NULL;
 	}
 	free(pci_addr);
-	if (slot == NULL || vmdssd_check_slot_module(slot->sysfs_path) < 0)
+	if (slot == NULL || !vmdssd_check_slot_module(slot->sysfs_path))
 		return NULL;
 
 	return slot;

--- a/src/vmdssd.h
+++ b/src/vmdssd.h
@@ -21,6 +21,8 @@
 #ifndef _VMDSSD_H
 #define _VMDSSD_H
 
+#include <stdbool.h>
+
 #include "block.h"
 #include "ibpi.h"
 #include "utils.h"
@@ -35,6 +37,6 @@ char *vmdssd_get_path(const char *cntrl_path);
 struct pci_slot *vmdssd_find_pci_slot(char *device_path);
 status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum ibpi_pattern ibpi);
 enum ibpi_pattern vmdssd_get_attention(struct pci_slot *slot);
-int vmdssd_check_slot_module(const char *slot_path);
+bool vmdssd_check_slot_module(const char *slot_path);
 
 #endif

--- a/src/vmdssd.h
+++ b/src/vmdssd.h
@@ -34,6 +34,7 @@
 
 int vmdssd_write(struct block_device *device, enum ibpi_pattern ibpi);
 char *vmdssd_get_path(const char *cntrl_path);
+char *vmdssd_get_domain(const char *path);
 struct pci_slot *vmdssd_find_pci_slot(char *device_path);
 status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum ibpi_pattern ibpi);
 enum ibpi_pattern vmdssd_get_attention(struct pci_slot *slot);

--- a/src/vmdssd.h
+++ b/src/vmdssd.h
@@ -35,5 +35,6 @@ char *vmdssd_get_path(const char *cntrl_path);
 struct pci_slot *vmdssd_find_pci_slot(char *device_path);
 status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum ibpi_pattern ibpi);
 enum ibpi_pattern vmdssd_get_attention(struct pci_slot *slot);
+int vmdssd_check_slot_module(const char *slot_path);
 
 #endif


### PR DESCRIPTION
Slots_list contained all of pci devices, but
only vmd devices should be present. Add checking
if attention and pciehp are available for each slot.