### PR TITLE
ledmon: Define ONESHOT_NORMAL for VMD

### DIFF
--- a/src/amd_ipmi.c
+++ b/src/amd_ipmi.c
@@ -45,6 +45,7 @@
 #include "amd.h"
 #include "ipmi.h"
 
+/* For IBPI_PATTERN_NORMAL and IBPI_PATTERN_ONESHOT_NORMAL _disable_all_ibpi_states is called. */
 const struct ibpi2value ibpi2amd_ipmi[] = {
 	{IBPI_PATTERN_PFA, 0x41},
 	{IBPI_PATTERN_LOCATE, 0x42},
@@ -347,7 +348,7 @@ static int _change_ibpi_state(struct amd_drive *drive, enum ibpi_pattern ibpi, b
 							ARRAY_SIZE(ibpi2amd_ipmi));
 
 	if (ibpi2val->ibpi == IBPI_PATTERN_UNKNOWN) {
-		log_error("AMD_IPMI: Controller doesn't support %s pattern\n", ibpi_str[ibpi]);
+		log_info("AMD_IPMI: Controller doesn't support %s pattern\n", ibpi_str[ibpi]);
 		return STATUS_INVALID_STATE;
 	}
 

--- a/src/npem.c
+++ b/src/npem.c
@@ -276,7 +276,7 @@ status_t npem_set_slot(char *slot_path, enum ibpi_pattern state)
 			       ARRAY_SIZE(ibpi_to_npem_capability));
 
 	if (ibpi2val->ibpi == IBPI_PATTERN_UNKNOWN) {
-		log_error("NPEM: Controller doesn't support %s pattern\n", ibpi_str[state]);
+		log_info("NPEM: Controller doesn't support %s pattern\n", ibpi_str[state]);
 		return STATUS_INVALID_STATE;
 	}
 	cap = (u32)ibpi2val->value;
@@ -294,8 +294,8 @@ status_t npem_set_slot(char *slot_path, enum ibpi_pattern state)
 	}
 
 	if (!is_mask_set(pdev, PCI_NPEM_CAP_REG, cap)) {
-		log_error("NPEM: Controller %s doesn't support %s pattern\n", slot_path,
-			  ibpi_str[state]);
+		log_info("NPEM: Controller %s doesn't support %s pattern\n", slot_path,
+			 ibpi_str[state]);
 		return STATUS_INVALID_STATE;
 	}
 	npem_wait_command(pdev);

--- a/src/vmdssd.c
+++ b/src/vmdssd.c
@@ -44,6 +44,7 @@ struct ibpi2value ibpi_to_attention[] = {
 	{IBPI_PATTERN_FAILED_DRIVE, ATTENTION_FAILURE},
 	{IBPI_PATTERN_REBUILD, ATTENTION_REBUILD},
 	{IBPI_PATTERN_LOCATE_OFF, ATTENTION_OFF},
+	{IBPI_PATTERN_ONESHOT_NORMAL, ATTENTION_OFF},
 	{IBPI_PATTERN_UNKNOWN}
 };
 
@@ -137,7 +138,7 @@ status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum ibpi_pattern ibp
 
 	ibpi2val = get_by_ibpi(ibpi, ibpi_to_attention, ARRAY_SIZE(ibpi_to_attention));
 	if (ibpi2val->ibpi == IBPI_PATTERN_UNKNOWN) {
-		log_error("VMD: Controller doesn't support %s pattern\n", ibpi_str[ibpi]);
+		log_info("VMD: Controller doesn't support %s pattern\n", ibpi_str[ibpi]);
 		return STATUS_INVALID_STATE;
 	}
 	val = (uint16_t)ibpi2val->value;


### PR DESCRIPTION
This pattern is used by ledmon internal logic. Must be defined. Add missing definition in VMD.
Make logging less verbose because ledmon may set patterns which are not supported- it is unnecessary to log it every time.

This will hide those logs in ledctl with default error log level too.