### PR TITLE
ledmon.c: allocate memory for ignore

### DIFF
--- a/src/ledmon.c
+++ b/src/ledmon.c
@@ -890,7 +890,7 @@ static void _close_parent_fds(void)
 int main(int argc, char *argv[])
 {
 	ledmon_status_code_t status = LEDMON_STATUS_SUCCESS;
-	int ignore = 0;
+	static int ignore;
 
 	setup_options(&longopt, &shortopt, possible_params,
 			possible_params_size);


### PR DESCRIPTION
Fix printing status on application exit.
In old solution ignore has been read from random memory (in function _ledmon_status) causing fake values to be checked. As result, exit status was never printed.