### PR TITLE
Slots list suggestions/fixes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,14 +19,14 @@
 COMMON_SRCS      = ahci.c block.c cntrl.c config_file.c enclosure.c list.c \
                    raid.c scsi.c slave.c sysfs.c smp.c dellssd.c \
                    utils.c pci_slot.c vmdssd.c udev.c amd.c amd_sgpio.c amd_ipmi.c\
-                   ipmi.c npem.c ses.c \
+                   ipmi.c npem.c ses.c slot.c \
                    ahci.h amd_sgpio.h block.h cntrl.h config_file.h dellssd.h \
                    enclosure.h ibpi.h list.h pci_slot.h pidfile.h raid.h scsi.h \
                    ses.h slave.h smp.h status.h sysfs.h udev.h utils.h \
-                   vmdssd.h ipmi.h amd.h amd_ipmi.h npem.h
+                   vmdssd.h ipmi.h amd.h amd_ipmi.h npem.h slot.h
 
 LEDMON_SRCS      = ledmon.c pidfile.c $(COMMON_SRCS)
-LEDCTL_SRCS      = ledctl.c slot.h $(COMMON_SRCS)
+LEDCTL_SRCS      = ledctl.c $(COMMON_SRCS)
 
 
 sbin_PROGRAMS  = ledmon ledctl

--- a/src/block.c
+++ b/src/block.c
@@ -216,7 +216,7 @@ struct _host_type *block_get_host(struct cntrl_device *cntrl, int host_id)
 	return hosts;
 }
 
-struct block_device *get_block_device_from_sysfs_path(char *sub_path)
+struct block_device *get_block_device_from_sysfs_path(char *sub_path, bool sub_path_to_end)
 {
 	struct block_device *device;
 
@@ -225,6 +225,8 @@ struct block_device *get_block_device_from_sysfs_path(char *sub_path)
 			if ((start_loc = strstr(device->sysfs_path, sub_path))) {
 				char following = start_loc[strnlen(sub_path, PATH_MAX)];
 				if (following == '/' || following == '\n' || following == '\0')
+					return device;
+				if (sub_path_to_end)
 					return device;
 			}
 	}

--- a/src/block.h
+++ b/src/block.h
@@ -21,6 +21,8 @@
 #ifndef _BLOCK_H_INCLUDED_
 #define _BLOCK_H_INCLUDED_
 
+#include <stdbool.h>
+
 #include "cntrl.h"
 #include "ibpi.h"
 #include "time.h"
@@ -241,6 +243,6 @@ int block_compare(const struct block_device *bd_old,
  *
  * @return first block device containing sub-path if any, otherwise NULL.
  */
-struct block_device *get_block_device_from_sysfs_path(char *sub_path);
+struct block_device *get_block_device_from_sysfs_path(char *sub_path, bool sub_path_to_end);
 
 #endif				/* _BLOCK_H_INCLUDED_ */

--- a/src/block.h
+++ b/src/block.h
@@ -239,7 +239,8 @@ int block_compare(const struct block_device *bd_old,
  * The character after the sub_path match is required to be one of the
  * following ('\n', '\0', '/'), otherwise it is excluded.
  *
- * @param[in]        sub_path        Sub path.
+ * @param[in]        sub_path            Sub path.
+ * @param[in]        sub_path_to_end     True if sub_path is complete path.
  *
  * @return first block device containing sub-path if any, otherwise NULL.
  */

--- a/src/enclosure.c
+++ b/src/enclosure.c
@@ -277,20 +277,21 @@ static status_t enclosure_get_slot_by_slot_num(char *slot_num, struct slot_respo
 static status_t enclosure_get_slot_by_device(char *device, struct slot_response *slot_res)
 {
 	char device_node[PATH_MAX] = {0,};
-	struct block_device *block_device = get_block_device_from_sysfs_path(basename(device));
+	struct block_device *bl_device = get_block_device_from_sysfs_path(basename(device), false);
 
-	if (!block_device) {
+	if (!bl_device) {
 		log_error("SCSI: Device node not found %s\n", device);
 		return STATUS_INVALID_PATH;
 	}
 
-	if (!block_device->enclosure) {
+	if (!bl_device->enclosure) {
 		log_error("SCSI: Not a SCSI ses device %n\n", device);
 		return STATUS_INVALID_PATH;
 	}
 
-	snprintf(device_node, PATH_MAX, "/dev/%s", basename(block_device->sysfs_path));
-	return _enclosure_get_slot(block_device->enclosure, block_device->encl_index, device_node, slot_res);
+	snprintf(device_node, PATH_MAX, "/dev/%s", basename(bl_device->sysfs_path));
+	return _enclosure_get_slot(bl_device->enclosure, bl_device->encl_index,
+				   device_node, slot_res);
 }
 
 status_t enclosure_get_slot(char *device, char *slot_num, struct slot_response *slot_res)

--- a/src/enclosure.h
+++ b/src/enclosure.h
@@ -88,30 +88,27 @@ void enclosure_device_fini(struct enclosure_device *enclosure);
 int enclosure_open(const struct enclosure_device *enclosure);
 
 /**
- * @brief Gets led state for slot.
+ * @brief Gets slot information.
  *
- * This function finds slot connected to given identifier
- * and fills slot response related to the slot.
+ * This function fills slot information related to the slot.
  *
- * @param[in]         device         Requested device name.
- * @param[in]         slot_num       Requested identifier of the slot.
- * @param[in]         slot_res       Pointer to the slot response.
+ * @param[in]         slot                Requested slot.
+ * @param[in]         slot_property       Pointer to the slot property element.
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t enclosure_get_slot(char *device, char *slot_num, struct slot_response *slot_res);
-
+enum ibpi_pattern enclosure_get_state(void *slot);
+struct slot_property *enclosure_slot_property_init(void *cntrl);
 /**
  * @brief Sets led state for slot.
  *
- * This function finds slot connected to given number or device name
- * and set given led state.
+ * This function sets given led state for slot.
  *
- * @param[in]         slot_num       Requested number of the slot.
+ * @param[in]         slot           Requested slot.
  * @param[in]         state          IBPI state based on slot request.
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t enclosure_set_slot(char *slot_num, enum ibpi_pattern state);
+status_t enclosure_set_slot(void *slot, enum ibpi_pattern state);
 
 #endif				/* _ENCLOSURE_H_INCLUDED_ */

--- a/src/enclosure.h
+++ b/src/enclosure.h
@@ -97,8 +97,8 @@ int enclosure_open(const struct enclosure_device *enclosure);
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-enum ibpi_pattern enclosure_get_state(void *slot);
-struct slot_property *enclosure_slot_property_init(void *cntrl);
+enum ibpi_pattern enclosure_get_state(struct slot_property *slot);
+
 /**
  * @brief Sets led state for slot.
  *
@@ -109,6 +109,15 @@ struct slot_property *enclosure_slot_property_init(void *cntrl);
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t enclosure_set_slot(void *slot, enum ibpi_pattern state);
+status_t enclosure_set_state(struct slot_property *slot, enum ibpi_pattern state);
+
+/**
+ * @brief Initializes a slot_property for a specified enclosure and slot number in that enclosure.
+ *
+ * @param[in]         enclosure       Specified enclosure for this slot
+ * @param[in]         slot_num        Specified slot number in this enclosure
+ * @return struct slot_property* if successful, else NULL on allocation failure
+ */
+struct slot_property *enclosure_slot_property_init(struct enclosure_device *enclosure, int slot_num);
 
 #endif				/* _ENCLOSURE_H_INCLUDED_ */

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -736,12 +736,12 @@ ledctl_status_code_t slot_execute(struct slot_request *slot_req)
 
 	switch (slot_req->chosen_opt) {
 	case OPT_SET_SLOT:
-		if (slot->c->get_state_fn(slot) == slot_req->state) {
+		if (get_slot_pattern(slot) == slot_req->state) {
 			log_warning("Led state: %s is already set for the slot.",
 				    ibpi2str(slot_req->state));
 			return LEDCTL_STATUS_SUCCESS;
 		}
-		return slot->c->set_slot_fn(slot, slot_req->state);
+		return set_slot_pattern(slot, slot_req->state);
 	case OPT_GET_SLOT:
 		print_slot_state(slot);
 		return LEDCTL_STATUS_SUCCESS;

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -110,31 +110,6 @@ struct ibpi_state {
 static struct list ibpi_list;
 
 /**
- * @brief Pointer to a get slot function.
- *
- * The pointer to a function which will print slot details.
- *
- * @param[in]         device        Name of the device.
- * @param[in]         slot          Unique identifier of the slot.
- * @param[in]         res           Pointer to slot response.
- *
- * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
- */
-typedef status_t (*get_slot_t) (char *device, char *slot, struct slot_response *res);
-
-/**
- * @brief Pointer to a set slot function.
- *
- * The pointer to a function which will set slot details.
- *
- * @param[in]         slot          Unique identifier of the slot.
- * @param[in]         state         IBPI state based on slot request.
- *
- * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
- */
-typedef status_t (*set_slot_t) (char *slot, enum ibpi_pattern state);
-
-/**
  * @brief slot request parametres
  *
  * This structure contains all possible parameters for slot related commands.
@@ -164,16 +139,6 @@ struct slot_request {
 	 * IBPI state.
 	 */
 	enum ibpi_pattern state;
-
-	/**
-	 * Pointer to the get slot function.
-	 */
-	get_slot_t get_slot_fn;
-
-	/**
-	 * Pointer to the set slot function.
-	 */
-	set_slot_t set_slot_fn;
 };
 
 /**
@@ -237,38 +202,6 @@ static int possible_params[] = {
 
 static const int possible_params_size = ARRAY_SIZE(possible_params);
 static int listed_only;
-
-/**
- * @brief Determines a slot functions based on controller.
- *
- * This function determines slot functions based on
- * controller type.
- *
- * @param[in]       ctrl_type       Controller type.
- * @param[in]       slot_req        Pointer to the slot request.
- *
- * @return This function does not return a value.
- */
-static void _get_slot_ctrl_fn(enum cntrl_type ctrl_type, struct slot_request *slot_req)
-{
-	switch (ctrl_type) {
-	case CNTRL_TYPE_VMD:
-		slot_req->get_slot_fn = pci_get_slot;
-		slot_req->set_slot_fn = pci_set_slot;
-		break;
-	case CNTRL_TYPE_NPEM:
-		slot_req->get_slot_fn = npem_get_slot;
-		slot_req->set_slot_fn = npem_set_slot;
-		break;
-	case CNTRL_TYPE_SCSI:
-		slot_req->get_slot_fn = enclosure_get_slot;
-		slot_req->set_slot_fn = enclosure_set_slot;
-		break;
-	default:
-		log_debug("Slot functions could not be set because the controller type %s does not "
-			  "support slots managing.", ctrl_type);
-	}
-}
 
 static void ibpi_state_fini(struct ibpi_state *p)
 {
@@ -724,17 +657,34 @@ static void slot_request_init(struct slot_request *slot_req)
 }
 
 /**
- * @brief Inits slot response structure with initial values.
+ * @brief List slots connected to given controller
  *
- * @param[in]       slot_res       structure with slot response
+ * This function scans all available slots connected to given controller
+ * and prints their led states and names of the connected devices (if exist).
  *
- * @return This function does not return a value.
+ * @param[in]       slot_req       Structure with slot request.
+ *
+ * @return LEDCTL_STATUS_SUCCESS if successful, otherwise ledctl_status_code_t.
  */
-static void slot_response_init(struct slot_response *slot_res)
+static ledctl_status_code_t list_slots(enum cntrl_type cntrl_type)
 {
-	memset(slot_res, 0, sizeof(struct slot_response));
+	struct slot_property *slot;
 
-	slot_res->state = IBPI_PATTERN_UNKNOWN;
+	list_for_each(sysfs_get_slots(), slot) {
+		if (slot->cntrl_type == cntrl_type)
+			print_slot_state(slot);
+	}
+
+	return STATUS_SUCCESS;
+}
+
+struct slot_property *find_slot(struct slot_request *slot_req)
+{
+	if (slot_req->device && slot_req->device[0] != '\0')
+		return find_slot_by_device_name(slot_req->device, slot_req->cntrl);
+	else if (slot_req->slot && slot_req->slot[0] != '\0')
+		return find_slot_by_slot_path(slot_req->slot, slot_req->cntrl);
+	return NULL;
 }
 
 /**
@@ -754,81 +704,16 @@ static ledctl_status_code_t slot_verify_request(struct slot_request *slot_req)
 		log_error("Invalid IBPI state in the request.");
 		return LEDCTL_STATUS_INVALID_STATE;
 	}
-	if (!slot_req->get_slot_fn && !slot_req->set_slot_fn) {
-		log_error("The controller type %s doesn't support slot functionality.",
-			cntrl_type_to_string(slot_req->cntrl));
-		return LEDCTL_STATUS_INVALID_CONTROLLER;
-	}
 	if (slot_req->device[0] && slot_req->slot[0]) {
 		log_error("Device and slot parameters are exclusive.");
 		return LEDCTL_STATUS_DATA_ERROR;
 	}
+	if (slot_req->chosen_opt != OPT_LIST_SLOTS && find_slot(slot_req) == NULL) {
+		log_error("Slot was not found for provided parameters.");
+		return LEDCTL_STATUS_CMDLINE_ERROR;
+	}
 
 	return LEDCTL_STATUS_SUCCESS;
-}
-
-static ledctl_status_code_t get_state_for_slot(char *slot, struct slot_request *slot_req)
-{
-	struct slot_response slot_res;
-	ledctl_status_code_t status = LEDCTL_STATUS_SUCCESS;
-
-	slot_response_init(&slot_res);
-	status = slot_req->get_slot_fn(NULL, slot, &slot_res);
-	if (status == LEDCTL_STATUS_SUCCESS)
-		print_slot_state(&slot_res);
-
-	return status;
-}
-
-/**
- * @brief List slots connected to given controller
- *
- * This function scans all available slots connected to given controller
- * and prints their led states and names of the connected devices (if exist).
- *
- * @param[in]       slot_req       Structure with slot request.
- *
- * @return LEDCTL_STATUS_SUCCESS if successful, otherwise ledctl_status_code_t.
- */
-static ledctl_status_code_t list_slots(struct slot_request *slot_req)
-{
-	ledctl_status_code_t status = LEDCTL_STATUS_SUCCESS;
-
-	switch (slot_req->cntrl) {
-	case CNTRL_TYPE_VMD:
-	{
-		struct pci_slot *slot;
-
-		list_for_each(sysfs_get_pci_slots(), slot)
-			status = get_state_for_slot(slot->sysfs_path, slot_req);
-		return status;
-	}
-	case CNTRL_TYPE_NPEM:
-	{
-		struct cntrl_device *ctrl_dev;
-
-		list_for_each(sysfs_get_cntrl_devices(), ctrl_dev) {
-			if (ctrl_dev->cntrl_type != CNTRL_TYPE_NPEM)
-				continue;
-			status = get_state_for_slot(ctrl_dev->sysfs_path, slot_req);
-		}
-		return status;
-	}
-	case CNTRL_TYPE_SCSI:
-	{
-		struct enclosure_device *encl = NULL;
-		char slot_id[PATH_MAX];
-		list_for_each(sysfs_get_enclosure_devices(), encl) {
-			for (int i = 0; i < encl->slots_count; i++) {
-				snprintf(slot_id, PATH_MAX, "%s/%d", encl->dev_path, encl->slots[i].index);
-				status = get_state_for_slot(slot_id, slot_req);
-			}
-		}
-		return status;
-	}
-	default:
-		return LEDCTL_STATUS_NOT_SUPPORTED;
-	}
 }
 
 /**
@@ -840,31 +725,26 @@ static ledctl_status_code_t list_slots(struct slot_request *slot_req)
  */
 ledctl_status_code_t slot_execute(struct slot_request *slot_req)
 {
-	struct slot_response slot_res;
-	ledctl_status_code_t status = LEDCTL_STATUS_SUCCESS;
+	struct slot_property *slot;
 
-	slot_response_init(&slot_res);
+	if (slot_req->chosen_opt == OPT_LIST_SLOTS)
+		return list_slots(slot_req->cntrl);
+
+	slot = find_slot(slot_req);
+	if (slot == NULL)
+		return LEDCTL_STATUS_DATA_ERROR;
 
 	switch (slot_req->chosen_opt) {
-	case OPT_LIST_SLOTS:
-		return list_slots(slot_req);
 	case OPT_SET_SLOT:
-		status = slot_req->get_slot_fn(slot_req->device, slot_req->slot, &slot_res);
-		if (status != LEDCTL_STATUS_SUCCESS)
-			return status;
-		if (slot_res.state == slot_req->state) {
+		if (slot->get_state_fn(slot->slot) == slot_req->state) {
 			log_warning("Led state: %s is already set for the slot.",
 				    ibpi2str(slot_req->state));
 			return LEDCTL_STATUS_SUCCESS;
 		}
-		status = slot_req->set_slot_fn(slot_res.slot, slot_req->state);
-		if (status != LEDCTL_STATUS_SUCCESS)
-			return status;
+		return slot->set_slot_fn(slot->slot, slot_req->state);
 	case OPT_GET_SLOT:
-		status = slot_req->get_slot_fn(slot_req->device, slot_req->slot, &slot_res);
-		if (status == LEDCTL_STATUS_SUCCESS)
-			print_slot_state(&slot_res);
-		return status;
+		print_slot_state(slot);
+		return LEDCTL_STATUS_SUCCESS;
 	default:
 		return LEDCTL_STATUS_NOT_SUPPORTED;
 	}
@@ -940,7 +820,6 @@ ledctl_status_code_t _cmdline_parse(int argc, char *argv[], struct slot_request 
 			break;
 		case 'c':
 			req->cntrl = string_to_cntrl_type(optarg);
-			_get_slot_ctrl_fn(req->cntrl, req);
 			break;
 		case 's':
 		{

--- a/src/ledctl.c
+++ b/src/ledctl.c
@@ -671,7 +671,7 @@ static ledctl_status_code_t list_slots(enum cntrl_type cntrl_type)
 	struct slot_property *slot;
 
 	list_for_each(sysfs_get_slots(), slot) {
-		if (slot->cntrl_type == cntrl_type)
+		if (slot->c->cntrl_type == cntrl_type)
 			print_slot_state(slot);
 	}
 
@@ -680,9 +680,9 @@ static ledctl_status_code_t list_slots(enum cntrl_type cntrl_type)
 
 struct slot_property *find_slot(struct slot_request *slot_req)
 {
-	if (slot_req->device && slot_req->device[0] != '\0')
+	if (slot_req->device[0] != '\0')
 		return find_slot_by_device_name(slot_req->device, slot_req->cntrl);
-	else if (slot_req->slot && slot_req->slot[0] != '\0')
+	else if (slot_req->slot[0] != '\0')
 		return find_slot_by_slot_path(slot_req->slot, slot_req->cntrl);
 	return NULL;
 }
@@ -736,12 +736,12 @@ ledctl_status_code_t slot_execute(struct slot_request *slot_req)
 
 	switch (slot_req->chosen_opt) {
 	case OPT_SET_SLOT:
-		if (slot->get_state_fn(slot->slot) == slot_req->state) {
+		if (slot->c->get_state_fn(slot) == slot_req->state) {
 			log_warning("Led state: %s is already set for the slot.",
 				    ibpi2str(slot_req->state));
 			return LEDCTL_STATUS_SUCCESS;
 		}
-		return slot->set_slot_fn(slot->slot, slot_req->state);
+		return slot->c->set_slot_fn(slot, slot_req->state);
 	case OPT_GET_SLOT:
 		print_slot_state(slot);
 		return LEDCTL_STATUS_SUCCESS;

--- a/src/npem.c
+++ b/src/npem.c
@@ -213,7 +213,7 @@ status_t npem_get_slot(char *device, char *slot_path, struct slot_response *slot
 	}
 
 	if (device && device[0] != '\0') {
-		block_device = get_block_device_from_sysfs_path(basename(device));
+		block_device = get_block_device_from_sysfs_path(basename(device), true);
 		if (block_device)
 			path = block_device->cntrl->sysfs_path;
 	} else if (slot_path && slot_path[0] != '\0') {
@@ -225,7 +225,7 @@ status_t npem_get_slot(char *device, char *slot_path, struct slot_response *slot
 			if (strcmp(basename(ctrl_dev->sysfs_path), basename(slot_path)) != 0)
 				continue;
 			path = ctrl_dev->sysfs_path;
-			block_device = get_block_device_from_sysfs_path(path);
+			block_device = get_block_device_from_sysfs_path(path, true);
 			break;
 		}
 	}

--- a/src/npem.h
+++ b/src/npem.h
@@ -30,29 +30,26 @@ int npem_write(struct block_device *device, enum ibpi_pattern ibpi);
 char *npem_get_path(const char *cntrl_path);
 
 /**
- * @brief Gets led state for slot.
+ * @brief Gets slot information.
  *
- * This function finds slot connected to given identifier
- * and fills slot response related to the slot.
+ * This function fills slot information related to the slot.
  *
- * @param[in]         device         Requested device name.
- * @param[in]         slot_num       Requested identifier of the slot.
- * @param[in]         slot_res       Pointer to the slot response.
+ * @param[in]         slot                Requested slot.
+ * @param[in]         slot_property       Pointer to the slot property element.
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t npem_get_slot(char *device, char *slot_num, struct slot_response *slot_res);
-
+enum ibpi_pattern npem_get_state(void *slot);
+struct slot_property *npem_slot_property_init(void *cntrl);
 /**
  * @brief Sets led state for slot.
  *
- * This function finds slot connected to given number or device name
- * and set given led state.
+ * This function sets given led state for slot.
  *
- * @param[in]         slot_num       Requested number of the slot.
+ * @param[in]         slot           Requested slot.
  * @param[in]         state          IBPI state based on slot request.
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t npem_set_slot(char *slot_num, enum ibpi_pattern state);
+status_t npem_set_slot(void *slot, enum ibpi_pattern state);
 #endif // NPEM_H_INCLUDED_

--- a/src/npem.h
+++ b/src/npem.h
@@ -39,8 +39,8 @@ char *npem_get_path(const char *cntrl_path);
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-enum ibpi_pattern npem_get_state(void *slot);
-struct slot_property *npem_slot_property_init(void *cntrl);
+enum ibpi_pattern npem_get_state(struct slot_property *slot);
+
 /**
  * @brief Sets led state for slot.
  *
@@ -51,5 +51,14 @@ struct slot_property *npem_slot_property_init(void *cntrl);
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t npem_set_slot(void *slot, enum ibpi_pattern state);
+status_t npem_set_state(struct slot_property *slot, enum ibpi_pattern state);
+
+/**
+ * @brief Initializes a slot_property for a specified npem controller.
+ *
+ * @param[in]         npem_cntrl       Specified npem controller for this slot
+ * @return struct slot_property* if successful, else NULL on allocation failure
+ */
+struct slot_property *npem_slot_property_init(struct cntrl_device *npem_cntrl);
+
 #endif // NPEM_H_INCLUDED_

--- a/src/pci_slot.c
+++ b/src/pci_slot.c
@@ -103,7 +103,7 @@ static status_t set_slot_response(struct pci_slot *slot, struct slot_response *s
 
 	slot_res->state = vmdssd_get_attention(slot);
 
-	bl_device = get_block_device_from_sysfs_path(slot->address);
+	bl_device = get_block_device_from_sysfs_path(slot->address, true);
 	if (bl_device)
 		snprintf(slot_res->device, PATH_MAX, "/dev/%s", basename(bl_device->sysfs_path));
 	else
@@ -124,7 +124,7 @@ status_t pci_get_slot(char *device, char *slot_path, struct slot_response *slot_
 			return STATUS_DATA_ERROR;
 		}
 
-		block_device = get_block_device_from_sysfs_path(sub_path + 1);
+		block_device = get_block_device_from_sysfs_path(sub_path + 1, true);
 		if (block_device == NULL) {
 			log_error("Device %s not found.", device);
 			return STATUS_DATA_ERROR;

--- a/src/pci_slot.h
+++ b/src/pci_slot.h
@@ -70,29 +70,27 @@ struct pci_slot *pci_slot_init(const char *path);
 void pci_slot_fini(struct pci_slot *slot);
 
 /**
- * @brief Gets led state for slot.
+ * @brief Gets slot information.
  *
- * This function finds slot connected to given identifier
- * and fills slot response related to the slot.
+ * This function fills slot information related to the slot.
  *
- * @param[in]         device         Requested device name.
- * @param[in]         slot_num       Requested identifier of the slot.
- * @param[in]         slot_res       Pointer to the slot response.
+ * @param[in]         slot                Requested slot.
+ * @param[in]         slot_property       Pointer to the slot property element.
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t pci_get_slot(char *device, char *slot_num, struct slot_response *slot_res);
+enum ibpi_pattern pci_get_state(void *slot);
+struct slot_property *pci_slot_property_init(void *slot);
 
 /**
  * @brief Sets led state for slot.
  *
- * This function finds slot connected to given number or device name
- * and set given led state.
+ * This function sets given led state for slot.
  *
- * @param[in]         slot_num       Requested number of the slot.
+ * @param[in]         slot           Requested slot.
  * @param[in]         state          IBPI state based on slot request.
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t pci_set_slot(char *slot_num, enum ibpi_pattern state);
+status_t pci_set_slot(void *slot, enum ibpi_pattern state);
 #endif // PCI_SLOT_H_INCLUDED_

--- a/src/pci_slot.h
+++ b/src/pci_slot.h
@@ -79,8 +79,7 @@ void pci_slot_fini(struct pci_slot *slot);
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-enum ibpi_pattern pci_get_state(void *slot);
-struct slot_property *pci_slot_property_init(void *slot);
+enum ibpi_pattern pci_get_state(struct slot_property *slot);
 
 /**
  * @brief Sets led state for slot.
@@ -92,5 +91,14 @@ struct slot_property *pci_slot_property_init(void *slot);
  *
  * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-status_t pci_set_slot(void *slot, enum ibpi_pattern state);
+status_t pci_set_slot(struct slot_property *slot, enum ibpi_pattern state);
+
+/**
+ * @brief Initializes a slot_property for a specified pci slot.
+ *
+ * @param[in]      pci_slot        The specified pci slot pointer for this slot
+ * @return struct slot_property* if successful, else NULL on allocation failure
+ */
+struct slot_property *pci_slot_property_init(struct pci_slot *pci_slot);
+
 #endif // PCI_SLOT_H_INCLUDED_

--- a/src/slot.c
+++ b/src/slot.c
@@ -1,0 +1,96 @@
+/*
+ * Intel(R) Enclosure LED Utilities
+ * Copyright (C) 2023-2023 Intel Corporation.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#if _HAVE_DMALLOC_H
+#include <dmalloc.h>
+#endif
+
+#include "enclosure.h"
+#include "npem.h"
+#include "slot.h"
+#include "sysfs.h"
+#include "pci_slot.h"
+
+struct slot_property *slot_init(void *cntrl, enum cntrl_type cntrl_type)
+{
+	switch (cntrl_type) {
+	case CNTRL_TYPE_VMD:
+		return pci_slot_property_init(cntrl);
+	case CNTRL_TYPE_NPEM:
+		return npem_slot_property_init(cntrl);
+	case CNTRL_TYPE_SCSI:
+		return enclosure_slot_property_init(cntrl);
+	default:
+		return NULL;
+	}
+}
+
+void slot_fini(struct slot_property *slot_property)
+{
+	if (slot_property)
+		free(slot_property);
+}
+
+void print_slot_state(struct slot_property *slot_property)
+{
+	char device_name[PATH_MAX];
+	enum ibpi_pattern led_state = slot_property->get_state_fn(slot_property->slot);
+
+	if (slot_property->bl_device)
+		snprintf(device_name, PATH_MAX, "/dev/%s",
+			 basename(slot_property->bl_device->sysfs_path));
+	else
+		snprintf(device_name, PATH_MAX, "(empty)");
+
+	printf("slot: %-15s led state: %-15s device: %-15s\n",
+		basename(slot_property->slot_id), ibpi2str(led_state), device_name);
+}
+
+struct slot_property *find_slot_by_device_name(char *device_name, enum cntrl_type cntrl_type)
+{
+	struct slot_property *slot;
+
+	list_for_each(sysfs_get_slots(), slot) {
+		if (slot->cntrl_type != cntrl_type)
+			continue;
+		if (slot->bl_device == NULL)
+			continue;
+		if (strncmp(basename(slot->bl_device->sysfs_path),
+			    basename(device_name), PATH_MAX) == 0)
+			return slot;
+	}
+	return NULL;
+}
+
+struct slot_property *find_slot_by_slot_path(char *slot_path, enum cntrl_type cntrl_type)
+{
+	struct slot_property *slot;
+
+	list_for_each(sysfs_get_slots(), slot) {
+		if (slot->cntrl_type != cntrl_type)
+			continue;
+		if (strncmp(basename(slot->slot_id), slot_path, PATH_MAX) == 0)
+			return slot;
+	}
+	return NULL;
+}

--- a/src/slot.c
+++ b/src/slot.c
@@ -31,30 +31,10 @@
 #include "sysfs.h"
 #include "pci_slot.h"
 
-struct slot_property *slot_init(void *cntrl, enum cntrl_type cntrl_type)
-{
-	switch (cntrl_type) {
-	case CNTRL_TYPE_VMD:
-		return pci_slot_property_init(cntrl);
-	case CNTRL_TYPE_NPEM:
-		return npem_slot_property_init(cntrl);
-	case CNTRL_TYPE_SCSI:
-		return enclosure_slot_property_init(cntrl);
-	default:
-		return NULL;
-	}
-}
-
-void slot_fini(struct slot_property *slot_property)
-{
-	if (slot_property)
-		free(slot_property);
-}
-
 void print_slot_state(struct slot_property *slot_property)
 {
 	char device_name[PATH_MAX];
-	enum ibpi_pattern led_state = slot_property->get_state_fn(slot_property->slot);
+	enum ibpi_pattern led_state = slot_property->c->get_state_fn(slot_property);
 
 	if (slot_property->bl_device)
 		snprintf(device_name, PATH_MAX, "/dev/%s",
@@ -71,7 +51,7 @@ struct slot_property *find_slot_by_device_name(char *device_name, enum cntrl_typ
 	struct slot_property *slot;
 
 	list_for_each(sysfs_get_slots(), slot) {
-		if (slot->cntrl_type != cntrl_type)
+		if (slot->c->cntrl_type != cntrl_type)
 			continue;
 		if (slot->bl_device == NULL)
 			continue;
@@ -87,7 +67,7 @@ struct slot_property *find_slot_by_slot_path(char *slot_path, enum cntrl_type cn
 	struct slot_property *slot;
 
 	list_for_each(sysfs_get_slots(), slot) {
-		if (slot->cntrl_type != cntrl_type)
+		if (slot->c->cntrl_type != cntrl_type)
 			continue;
 		if (strncmp(basename(slot->slot_id), slot_path, PATH_MAX) == 0)
 			return slot;

--- a/src/slot.c
+++ b/src/slot.c
@@ -74,3 +74,13 @@ struct slot_property *find_slot_by_slot_path(char *slot_path, enum cntrl_type cn
 	}
 	return NULL;
 }
+
+status_t set_slot_pattern(struct slot_property *slot, enum ibpi_pattern state)
+{
+	return slot->c->set_slot_fn(slot, state);
+}
+
+enum ibpi_pattern get_slot_pattern(struct slot_property *slot)
+{
+	return slot->c->get_state_fn(slot);
+}

--- a/src/slot.h
+++ b/src/slot.h
@@ -1,19 +1,20 @@
 /*
  * Intel(R) Enclosure LED Utilities
- * Copyright (C) 2022-2022 Intel Corporation.
+ * Copyright (C) 2023-2023 Intel Corporation.
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
  *
- * This program is distributed in the hope it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
 
@@ -22,42 +23,93 @@
 
 #include <stdio.h>
 
+#include "block.h"
+#include "cntrl.h"
 #include "ibpi.h"
 #include "utils.h"
 
 /**
- * @brief slot response parameters
+ * @brief slot property parameters
  *
- * This structure contains slot properties.
+ * This structure contains slot parameters.
  */
-struct slot_response {
+struct slot_property {
 	/**
-	 * Name of the device.
+	 * Block device (if exists for slot).
 	 */
-	char device[PATH_MAX];
+	struct block_device *bl_device;
 
 	/**
-	 * Unique slot identifier.
+	 * Unique slot.
 	 */
-	char slot[PATH_MAX];
+	void *slot;
 
 	/**
-	 * IBPI state.
+	 * Unique slot ID.
 	 */
-	enum ibpi_pattern state;
+	char slot_id[PATH_MAX];
+
+	/**
+	 * Controller type which is being represented by slot.
+	 */
+	enum cntrl_type cntrl_type;
+
+	/**
+	 * Pointer to the set slot function.
+	 */
+	status_t (*set_slot_fn)(void *slot, enum ibpi_pattern state);
+
+	/**
+	 * Pointer to the get led state function.
+	 */
+	enum ibpi_pattern (*get_state_fn)(void *slot);
 };
+
+/**
+ * @brief Init slot and fill its parameters.
+ *
+ * @param[in]        cntrl        Device for controller.
+ *
+ * @return This function does not return a value.
+ */
+struct slot_property *slot_init(void *cntrl, enum cntrl_type cntrl_type);
+
+/**
+ * @brief Free slot.
+ *
+ * @param[in]        cntrl        Slot parameters.
+ *
+ * @return This function does not return a value.
+ */
+void slot_fini(struct slot_property *slot);
 
 /**
  * @brief Print address, slot identifier and led state.
  *
- * @param[in]        res        Structure with slot response.
+ * @param[in]        res        Structure with slot.
  *
  * @return This function does not return a value.
  */
-static inline void print_slot_state(struct slot_response *res)
-{
-	printf("slot: %-15s led state: %-15s device: %-15s\n",
-		res->slot, ibpi2str(res->state), res->device);
-}
+void print_slot_state(struct slot_property *res);
+
+/**
+ * @brief Find slot device by path to slot.
+ *
+ * @param[in]        slot_path        Path to slot.
+ * @param[in]        cntrl_type       Type of controller.
+ *
+ * @return This function returns related slot property.
+ */
+struct slot_property *find_slot_by_slot_path(char *slot_path, enum cntrl_type cntrl_type);
+
+/**
+ * @brief Find slot device by device name.
+ *
+ * @param[in]        device_name       Device name.
+ * @param[in]        cntrl_type       Type of controller.
+ *
+ * @return This function returns related slot property.
+ */
+struct slot_property *find_slot_by_device_name(char *device_name, enum cntrl_type cntrl_type);
 
 #endif // SLOT_H_INCLUDED_

--- a/src/slot.h
+++ b/src/slot.h
@@ -119,4 +119,21 @@ struct slot_property *find_slot_by_slot_path(char *slot_path, enum cntrl_type cn
  */
 struct slot_property *find_slot_by_device_name(char *device_name, enum cntrl_type cntrl_type);
 
+/**
+ * @brief Set the slot pattern for the given slot
+ *
+ * @param[in]      slot       The slot to change the ibpi_pattern
+ * @param[in]      state      The desired ibpi pattern for the slot
+ * @return status_t
+ */
+status_t set_slot_pattern(struct slot_property *slot, enum ibpi_pattern state);
+
+/**
+ * @brief Get the slot pattern
+ *
+ * @param[in]      slot        The slot to retrieve the ibpi pattern
+ * @return enum ibpi_pattern
+ */
+enum ibpi_pattern get_slot_pattern(struct slot_property *slot);
+
 #endif // SLOT_H_INCLUDED_

--- a/src/slot.h
+++ b/src/slot.h
@@ -28,27 +28,15 @@
 #include "ibpi.h"
 #include "utils.h"
 
+/* Forward decl. */
+struct slot_property;
+
+
 /**
- * @brief slot property parameters
+ * @brief slot property attributes which are the same across slots of a specific type
  *
- * This structure contains slot parameters.
  */
-struct slot_property {
-	/**
-	 * Block device (if exists for slot).
-	 */
-	struct block_device *bl_device;
-
-	/**
-	 * Unique slot.
-	 */
-	void *slot;
-
-	/**
-	 * Unique slot ID.
-	 */
-	char slot_id[PATH_MAX];
-
+struct slot_property_common {
 	/**
 	 * Controller type which is being represented by slot.
 	 */
@@ -57,31 +45,50 @@ struct slot_property {
 	/**
 	 * Pointer to the set slot function.
 	 */
-	status_t (*set_slot_fn)(void *slot, enum ibpi_pattern state);
+	status_t (*set_slot_fn)(struct slot_property *slot, enum ibpi_pattern state);
 
 	/**
 	 * Pointer to the get led state function.
 	 */
-	enum ibpi_pattern (*get_state_fn)(void *slot);
+	enum ibpi_pattern (*get_state_fn)(struct slot_property *slot);
 };
 
 /**
- * @brief Init slot and fill its parameters.
+ * @brief Encapsulates information for enclosure
  *
- * @param[in]        cntrl        Device for controller.
- *
- * @return This function does not return a value.
  */
-struct slot_property *slot_init(void *cntrl, enum cntrl_type cntrl_type);
+struct ses_slot_info {
+	struct enclosure_device *encl;
+	int slot_num;
+};
 
 /**
- * @brief Free slot.
+ * @brief slot property parameters
  *
- * @param[in]        cntrl        Slot parameters.
- *
- * @return This function does not return a value.
+ * This structure contains slot parameters.
  */
-void slot_fini(struct slot_property *slot);
+struct slot_property {
+	const struct slot_property_common *c;
+
+	/**
+	 * Block device (if exists for slot).
+	 */
+	struct block_device *bl_device;
+
+	/**
+	 * Different payload based on slot type
+	 */
+	union {
+		struct pci_slot *pci;
+		struct cntrl_device *cntrl;
+		struct ses_slot_info ses;
+	} slot_spec;
+
+	/**
+	 * Unique slot ID.
+	 */
+	char slot_id[PATH_MAX];
+};
 
 /**
  * @brief Print address, slot identifier and led state.

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -1,6 +1,6 @@
 /*
  * Intel(R) Enclosure LED Utilities
- * Copyright (C) 2022-2022 Intel Corporation.
+ * Copyright (C) 2022-2023 Intel Corporation.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -104,7 +104,7 @@ static struct list enclo_list;
  * function to initialize the variable. Use sysfs_scan() function to populate
  * the list. Use sysfs_reset() function to delete the content of the list.
  */
-static struct list slots_list;
+static struct list pci_slots_list;
 
 /**
  * @brief Determine device type.
@@ -347,11 +347,11 @@ static void _enclo_add(const char *path)
 
 /**
  */
-static void _slots_add(const char *path)
+static void _pci_slots_add(const char *path)
 {
 	struct pci_slot *device = pci_slot_init(path);
 	if (device)
-		list_append(&slots_list, device);
+		list_append(&pci_slots_list, device);
 }
 
 /**
@@ -451,14 +451,14 @@ static void _scan_enclo(void)
 	}
 }
 
-static void _scan_slots(void)
+static void _scan_pci_slots(void)
 {
 	struct list dir;
 	if (scan_dir(SYSFS_PCI_SLOTS, &dir) == 0) {
 		const char *dir_path;
 
 		list_for_each(&dir, dir_path)
-			_slots_add(dir_path);
+			_pci_slots_add(dir_path);
 		list_erase(&dir);
 	}
 }
@@ -583,7 +583,7 @@ void sysfs_init(void)
 	list_init(&slave_list, (item_free_t)slave_device_fini);
 	list_init(&cntnr_list, (item_free_t)raid_device_fini);
 	list_init(&enclo_list, (item_free_t)enclosure_device_fini);
-	list_init(&slots_list, (item_free_t)pci_slot_fini);
+	list_init(&pci_slots_list, (item_free_t)pci_slot_fini);
 }
 
 void sysfs_reset(void)
@@ -594,14 +594,14 @@ void sysfs_reset(void)
 	list_erase(&slave_list);
 	list_erase(&cntnr_list);
 	list_erase(&enclo_list);
-	list_erase(&slots_list);
+	list_erase(&pci_slots_list);
 }
 
 void sysfs_scan(void)
 {
 	_scan_enclo();
 	_scan_cntrl();
-	_scan_slots();
+	_scan_pci_slots();
 	_scan_block();
 	_scan_raid();
 	_scan_slave();
@@ -641,7 +641,7 @@ const struct list *sysfs_get_block_devices(void)
 
 const struct list *sysfs_get_pci_slots(void)
 {
-	return &slots_list;
+	return &pci_slots_list;
 }
 
 /*

--- a/src/sysfs.c
+++ b/src/sysfs.c
@@ -38,6 +38,7 @@
 #include "enclosure.h"
 #include "ibpi.h"
 #include "list.h"
+#include "npem.h"
 #include "pci_slot.h"
 #include "raid.h"
 #include "slave.h"
@@ -363,14 +364,6 @@ static void _pci_slots_add(const char *path)
 		list_append(&pci_slots_list, device);
 }
 
-static void _slots_add(void *cntrl, enum cntrl_type cntrl_type)
-{
-	struct slot_property *slot = slot_init(cntrl, cntrl_type);
-
-	if (slot)
-		list_append(&slots_list, slot);
-}
-
 /**
  */
 static void _check_raid(const char *path)
@@ -484,15 +477,29 @@ static void _scan_slots(void)
 {
 	struct pci_slot *pci_slot;
 	struct cntrl_device *cntrl_device;
+	struct enclosure_device *encl;
+	struct slot_property *slot;
 
 	list_for_each(sysfs_get_cntrl_devices(), cntrl_device) {
-		// now NPEM and SCSI are supported
-		if (cntrl_device->cntrl_type == CNTRL_TYPE_NPEM ||
-		    cntrl_device->cntrl_type == CNTRL_TYPE_SCSI)
-			_slots_add(cntrl_device, cntrl_device->cntrl_type);
+		if (cntrl_device->cntrl_type == CNTRL_TYPE_NPEM) {
+			slot = npem_slot_property_init(cntrl_device);
+			if (slot)
+				list_append(&slots_list, slot);
+		}
 	}
+
 	list_for_each(sysfs_get_pci_slots(), pci_slot) {
-		_slots_add(pci_slot, CNTRL_TYPE_VMD);
+		slot = pci_slot_property_init(pci_slot);
+		if (slot)
+			list_append(&slots_list, slot);
+	}
+
+	list_for_each(sysfs_get_enclosure_devices(), encl) {
+		for (int i = 0; i < encl->slots_count; i++) {
+			slot = enclosure_slot_property_init(encl, i);
+			if (slot)
+				list_append(&slots_list, slot);
+		}
 	}
 }
 
@@ -617,7 +624,7 @@ void sysfs_init(void)
 	list_init(&cntnr_list, (item_free_t)raid_device_fini);
 	list_init(&enclo_list, (item_free_t)enclosure_device_fini);
 	list_init(&pci_slots_list, (item_free_t)pci_slot_fini);
-	list_init(&slots_list, (item_free_t)slot_fini);
+	list_init(&slots_list, NULL);
 }
 
 void sysfs_reset(void)

--- a/src/sysfs.h
+++ b/src/sysfs.h
@@ -76,6 +76,12 @@ const struct list *sysfs_get_block_devices(void);
 const struct list *sysfs_get_pci_slots(void);
 
 /**
+ * The function returns list of slots for supported controllers
+ * present in the system.
+ */
+const struct list *sysfs_get_slots(void);
+
+/**
  * The function checks if the given storage controller is attached to enclosure
  * device(s).
  */

--- a/test/exercise_ledctl.py
+++ b/test/exercise_ledctl.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python3
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2023 Red Hat Inc.
+
+# Simple tests for ledctl.  This needs to be expanded.
+
+import sys
+import subprocess
+import re
+
+LEDCTL_BIN = "/usr/sbin/ledctl"
+SLOT_LINE = re.compile(r"^slot: (.+)led state:(.+)device:(.+)$")
+
+SLOT_FILTERS = []
+
+# Note:
+# RH SES lab hardware has some enclosures which don't work, which includes the ses tools from sg_utils
+# and libStorageMgmt, so it's not something specific with ledmon project.
+#
+# To run this test do ./exercise_led_ctl ../src/ledctl sg3- sg2-
+# to filter out enclosures that don't work
+#
+# exit code == 0 -> success
+
+
+class Slot:
+    def __init__(self, cntrl, slot_id, state, device_node):
+        self.cntrl = cntrl
+        self.slot = slot_id
+        self.state = state.lower()
+        self.device_node = None
+        if device_node.startswith('/dev/'):
+            self.device_node = device_node
+
+    def __str__(self):
+        return "slot: %s state: %s device: %s" % (self.slot, self.state, self.device_node)
+
+
+def get_controllers_with_slot_functionality():
+    rc = {}
+    result = subprocess.run([LEDCTL_BIN, "--list-controllers"], capture_output=True)
+    if result.returncode == 0:
+        out = result.stdout.decode("utf-8")
+        for raw_line in out.split("\n"):
+            line = raw_line.strip()
+            if "SCSI" in line:
+                rc["SCSI"] = True
+            elif "VMD" in line:
+                rc["VMD"] = True
+            elif "NPEM" in line:
+                rc["NPEM"] = True
+    return rc.keys()
+
+
+def process_slot_line(controller, rawline):
+    line = rawline.strip()
+    match = SLOT_LINE.match(line)
+    if match is not None:
+        slot = Slot(controller, match.group(1).strip(), match.group(2).strip(), match.group(3).strip())
+        for slot_filter in SLOT_FILTERS:
+            if slot.slot.startswith(slot_filter):
+                # Filter out this slot
+                return None
+        return slot
+    return None
+
+
+def get_slot(slot_o):
+    result = subprocess.run([LEDCTL_BIN,
+                             "--get-slot",
+                             "--controller", slot_o.cntrl,
+                             "--slot", slot_o.slot], capture_output=True)
+    if result.returncode == 0:
+        out = result.stdout.decode("utf-8")
+        slot = process_slot_line(slot_o.cntrl, out)
+        return slot
+    else:
+        print("Failed to set slot: {result}")
+        return None
+
+
+def get_slots(controller):
+    rc = []
+    result = subprocess.run([LEDCTL_BIN, "--list-slots", "--controller", controller], capture_output=True)
+    if result.returncode == 0:
+        out = result.stdout.decode("utf-8")
+        for l in out.split("\n"):
+            s = process_slot_line(controller, l)
+            if s is not None:
+                rc.append(s)
+    return rc
+
+
+def set_slot_state(slot_o, state):
+    result = subprocess.run([LEDCTL_BIN,
+                             "--set-slot",
+                             "--controller", slot_o.cntrl,
+                             "--slot", slot_o.slot,
+                             "--state", state], capture_output=True)
+    if result.returncode == 0:
+        return True
+    else:
+        print("Failed to set slot: {result}")
+        return False
+
+
+def get_all_slots():
+    all_slots = []
+    for controller in get_controllers_with_slot_functionality():
+        all_slots.extend(get_slots(controller))
+    return all_slots
+
+
+def set_state_by_dev_node(dev_node, state):
+    option = "%s=%s" % (state, dev_node)
+    result = subprocess.run([LEDCTL_BIN, option], capture_output=True)
+    if result.returncode == 0:
+        return True
+    else:
+        print(f"Error while using led non slot syntax {option} {result}")
+        return False
+
+
+def test_non_slot_set_path():
+    """
+    Test setting the led status by using non-slot syntax, eg. ledctl locate=/dev/sda
+    :return:
+    """
+    slots_with_device_nodes = [s for s in get_all_slots() if s.device_node is not None]
+
+    for slot in slots_with_device_nodes:
+        for state in ["failure", "locate", "normal"]:
+            set_state_by_dev_node(slot.device_node, state)
+            cur = get_slot(slot)
+            if cur.state != state:
+                print(f"unable to set from {slot} to {state}, current = {cur} using non-slot syntax")
+                sys.exit(1)
+
+
+def test_slot_state_walk():
+    """
+    Test that we can set slots to different states and verify that they reported a change
+    :return:
+    """
+    slots = get_all_slots()
+
+    for slot in slots:
+        for state in ["locate", "failure", "normal"]:
+            result = set_slot_state(slot, state)
+            if not result:
+                print("failed to set slot state")
+                sys.exit(1)
+            cur = get_slot(slot)
+            if cur.state != state:
+                print(f"unable to set from {slot} to {state}, current = {cur}")
+                sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"syntax: {sys.argv[0]} <ledctl binary>")
+        sys.exit(1)
+    elif len(sys.argv) > 2:
+        # optional slots to skip as known to be not working
+        SLOT_FILTERS = sys.argv[2:]
+        print(f"slot filter = {SLOT_FILTERS}")
+
+    LEDCTL_BIN = sys.argv[1]
+    test_non_slot_set_path()
+    test_slot_state_walk()
+    sys.exit(0)
+


### PR DESCRIPTION
This is PR https://github.com/intel/ledmon/pull/132 with some of the commits squashed and my changes added to it.  This PR includes changes for:

* Refactoring/changes to slot list additions:

   * `void *` is not the primary parameter in the slot api.  Instead it's
        using the slot pointer itself, just as you would do in some OOP supported
        languages.
  * Factors out the redundant information from slots and
        adds a union so that we can hold the needed parts for each of the
        different slot implementations while maintaining type checking, removes the need
      for casts.  Memory savings is negligible as the union uses more space.
  * Removes the generic `slot_init` function as internally is was
        just a switch based on type.  Instead each slot implementation
        has its own initialization function so that it can take the precise
        parameters it needs.  Then we simply create them in each of the loops
        while we are processing them in `_scan_slots`.
  * The enclosure/ses slot_id no longer needs to be parsed as we hold what
        is needed in the the structure itself.  The slot_id is just the
        unique identifier for look ups.
  * I removed the `slot_fini` function as we can simply just use the default
        free in the list implementation.
  * The slot_property callback for getting slot is returning an ipbi_pattern,
        thus the get function cannot return an error.  I updated the return values
        in error paths to IBPI_PATTERN_UNKNOWN.  We may want to consider changing
        this to return a `status_t` with the ibpi_pattern as a pass out parameter.

* The addition of  ledctl test `test/exercise_ledctl.py` which is quite simple and could benefit from more additions, see: https://github.com/intel/ledmon/commit/333ab0e5d0e16d3cd3698b3067f3220afc2c6756  Please try running this on VMD & NPEM hardware.  I'm also thinking about converting this to use pyunit.

* The last commit is some things I found during a review which includes a resource leak in an error path for `npem_set_slot`.

This PR also restores SES functionality:

```bash
# ./ledctl --list-slots --controller SCSI
/dev/shm/ledmon.conf: does not exist, using global config file
/etc/ledmon.conf: does not exist, using built-in defaults
slot: sg43-0          led state: NORMAL          device: /dev/sdw       
slot: sg43-1          led state: NORMAL          device: /dev/sdx       
slot: sg43-2          led state: NORMAL          device: /dev/sdy       
slot: sg43-3          led state: NORMAL          device: /dev/sdz       
slot: sg43-4          led state: NORMAL          device: /dev/sdaa      
slot: sg43-5          led state: NORMAL          device: /dev/sdab      
slot: sg43-6          led state: NORMAL          device: /dev/sdac      
slot: sg43-7          led state: NORMAL          device: /dev/sdad      
slot: sg43-8          led state: NORMAL          device: /dev/sdae      
slot: sg43-9          led state: NORMAL          device: /dev/sdaf      
slot: sg43-10         led state: NORMAL          device: /dev/sdag      
slot: sg43-11         led state: NORMAL          device: /dev/sdah      
slot: sg43-12         led state: NORMAL          device: /dev/sdai      
slot: sg43-13         led state: NORMAL          device: /dev/sdaj      
slot: sg43-14         led state: NORMAL          device: /dev/sdak      
slot: sg43-15         led state: NORMAL          device: /dev/sdal      
slot: sg48-0          led state: NORMAL          device: /dev/sdam      
slot: sg48-1          led state: NORMAL          device: /dev/sdan      
slot: sg48-2          led state: NORMAL          device: (empty)        
slot: sg48-3          led state: NORMAL          device: (empty)        
slot: sg48-4          led state: NORMAL          device: (empty)        
slot: sg48-5          led state: NORMAL          device: (empty)        
slot: sg48-6          led state: NORMAL          device: (empty)        
slot: sg48-7          led state: NORMAL          device: (empty)        
slot: sg48-8          led state: NORMAL          device: (empty)        
slot: sg48-9          led state: NORMAL          device: (empty)        
slot: sg48-10         led state: NORMAL          device: (empty)        
slot: sg48-11         led state: NORMAL          device: (empty)        
slot: sg48-12         led state: NORMAL          device: /dev/sdao      
slot: sg48-13         led state: NORMAL          device: /dev/sdap      
slot: sg48-14         led state: NORMAL          device: (empty)        
slot: sg48-15         led state: NORMAL          device: (empty)        
...
```