### PR TITLE
Add gcc 12 to github review action

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,7 +17,7 @@ jobs:
     name: Compilation test with gcc
     strategy:
       matrix:
-        gcc-version: [7, 8, 9, 10, 11]
+        gcc-version: [7, 8, 9, 10, 11, 12]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
gcc 12 was not included.