### PR TITLE
Ignore meaningless checkpatch errors

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -7,3 +7,4 @@
 --ignore PREFER_PACKED
 --ignore NEW_TYPEDEFS
 --ignore PREFER_PRINTF
+--ignore EMAIL_SUBJECT

--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,4 +1,9 @@
 --no-tree
+--show-types
 --ignore FILE_PATH_CHANGES
 --ignore GIT_COMMIT_ID
 --ignore SPDX_LICENSE_TAG
+--ignore FSF_MAILING_ADDRESS
+--ignore PREFER_PACKED
+--ignore NEW_TYPEDEFS
+--ignore PREFER_PRINTF


### PR DESCRIPTION
Checkpatch has some checks specific for kernel code submission, that are meaningless for ledmon, such as:

`ERROR: Do not include the paragraph about writing to the Free Software Foundation's mailing address from the sample GPL notice. The FSF has changed addresses in the past, and may do so again. Linux already includes a copy of the GPL.`

`WARNING: Prefer __printf(3, 4) over __attribute__((format(printf, 3, 4)))`

`WARNING: Prefer __packed over __attribute__((__packed__))`

We need to ignore them.

False-positives found in: https://github.com/intel/ledmon/pull/115
