### PR TITLE
Fix build with Musl libc

### DIFF
--- a/src/ledctl/ledctl.c
+++ b/src/ledctl/ledctl.c
@@ -205,15 +205,11 @@ static void ibpi_state_fini(struct ibpi_state *p)
  *
  * This is internal function of ledctl utility. The function cleans up a memory
  * allocated for the application and closes all opened handles. This function is
- * design to be registered as on_exit() handler function.
- *
- * @param[in]      status         exit status of the ledctl application.
- * @param[in]      ignored        function ignores this argument.
+ * design to be registered as atexit() handler function.
  *
  * @return The function does not return a value.
  */
-static void _ledctl_fini(int status __attribute__ ((unused)),
-			 void *ignore __attribute__ ((unused)))
+static void _ledctl_fini(void)
 {
 	led_free(ctx);
 	list_erase(&ibpi_list);
@@ -945,7 +941,7 @@ static led_status_t load_library_prefs(void)
  * @brief Application's entry point.
  *
  * This is the entry point of ledctl utility. This function does all the work.
- * It allocates and initializes all used structures. Registers on_exit()
+ * It allocates and initializes all used structures. Registers atexit()
  * handlers.
  * Then the function parses command line options and commands given and scans
  * sysfs tree for controllers, block devices and RAID devices. If no error is
@@ -989,7 +985,7 @@ int main(int argc, char *argv[])
 	if (status != LEDCTL_STATUS_SUCCESS)
 		return status;
 
-	if (on_exit(_ledctl_fini, progname))
+	if (atexit(_ledctl_fini))
 		exit(LEDCTL_STATUS_ONEXIT_ERROR);
 
 	status = _read_shared_conf();

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -33,7 +33,6 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 #include <assert.h>

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -22,6 +22,7 @@
 #define _UTILS_H_INCLUDED_
 
 #include <getopt.h>
+#include <sys/types.h>
 #include <common/config_file.h>
 #include "stdlib.h"
 #include "stdint.h"


### PR DESCRIPTION
Hello friends!

I tried to build ledmon with toolchain which uses musl libc and faced with two problems:
- missing header for ssize_t type
- missing on_exit() function which is not portable and not available on the C libraries musl and uClibc

Here is pull request to solve these problems.