### PR TITLE
Add compiler defenses flags

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -26,7 +26,7 @@ jobs:
     - name: 'Install gcc'
       run: sudo apt-get update && sudo apt-get install gcc-${{ matrix.gcc-version }} g++-${{ matrix.gcc-version }}
     - name: 'Install dependencies'
-      run: sudo apt-get install pkg-config automake autoconf make libsgutils2-dev libudev-dev libpci-dev check
+      run: sudo apt-get install pkg-config automake autoconf autoconf-archive make libsgutils2-dev libudev-dev libpci-dev check
     - name: 'Generate compiling configurations'
       run: ./autogen.sh && ./configure --enable-test --enable-library
     - name: 'Make'

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Following packages are required to compile:
 | `pkgconf`, `RHEL7: pkgconfig`  | `pkg-config` | `pkg-config` |
 | `automake` | `automake`   | `automake`   |
 | `autoconf` | `autoconf`   | `autoconf`   |
+| `autoconf-archive` | `autoconf-archive` | `autoconf-archive` |
 | `gcc` | `gcc` | `gcc` |
  | `libtool` | `libtool` | `libtool` |
 | `make` | `make` | `make` |

--- a/configure.ac
+++ b/configure.ac
@@ -56,21 +56,19 @@ AM_CFLAGS='-Wall -I../config'
 AM_CPPFLAGS='-D_DEBUG -D_GNU_SOURCE -D_DEFAULT_SOURCE -DDMALLOC_DISABLE -DBUILD_LABEL=\""$(BUILD_LABEL)"\"'
 
 AC_DEFUN([AX_AM_CFLAGS_ADD],[AX_CHECK_COMPILE_FLAG($1, AM_CFLAGS="$AM_CFLAGS $1")])
-AX_AM_CFLAGS_ADD([-Wformat -Wformat-security -Werror=format-security])
-AX_AM_CFLAGS_ADD([-Werror=format-overflow=2])
+AX_AM_CFLAGS_ADD([-Wformat -Wformat-security -Werror])
+AX_AM_CFLAGS_ADD([-Wformat-overflow=2])
 AX_AM_CFLAGS_ADD([-Wno-strict-overflow])
 AX_AM_CFLAGS_ADD([-fno-delete-null-pointer-checks])
 AX_AM_CFLAGS_ADD([-Wwrapv])
-AX_AM_CFLAGS_ADD([-Werror=format-truncation=1])
-AX_AM_CFLAGS_ADD([-Werror=shift-negative-value])
-AX_AM_CFLAGS_ADD([-Werror=alloca])
-AX_AM_CFLAGS_ADD([-Werror=missing-field-initializers])
-AX_AM_CFLAGS_ADD([-Werror=format-signedness])
-AX_AM_CFLAGS_ADD([-fvisibility=hidden])
+AX_AM_CFLAGS_ADD([-Wformat-truncation=1])
+AX_AM_CFLAGS_ADD([-Wshift-negative-value])
+AX_AM_CFLAGS_ADD([-Walloca])
+AX_AM_CFLAGS_ADD([-Wmissing-field-initializers])
+AX_AM_CFLAGS_ADD([-Wformat-signedness])
 AX_AM_CFLAGS_ADD([-D_FORTIFY_SOURCE=2])
 AX_AM_CFLAGS_ADD([-fstack-protector-strong])
 AX_AM_CFLAGS_ADD([-fPIE])
-AX_AM_CFLAGS_ADD([-fPIC -shared])
 
 # Add linker flags.
 AC_DEFUN([AX_AM_LDFLAGS_ADD],[AX_CHECK_LINK_FLAG($1, AM_LDFLAGS="$AM_LDFLAGS $1")])

--- a/configure.ac
+++ b/configure.ac
@@ -51,12 +51,12 @@ AC_PROG_INSTALL
 
 AC_CONFIG_HEADERS([config_ac.h])
 
+# Add compiler flags.
 AM_CFLAGS='-Wall -I../config'
 AM_CPPFLAGS='-D_DEBUG -D_GNU_SOURCE -D_DEFAULT_SOURCE -DDMALLOC_DISABLE -DBUILD_LABEL=\""$(BUILD_LABEL)"\"'
 
-
 AC_DEFUN([AX_AM_CFLAGS_ADD],[AX_CHECK_COMPILE_FLAG($1, AM_CFLAGS="$AM_CFLAGS $1")])
-AX_AM_CFLAGS_ADD([-Wformat -Werror=format-security])
+AX_AM_CFLAGS_ADD([-Wformat -Wformat-security -Werror=format-security])
 AX_AM_CFLAGS_ADD([-Werror=format-overflow=2])
 AX_AM_CFLAGS_ADD([-Wno-strict-overflow])
 AX_AM_CFLAGS_ADD([-fno-delete-null-pointer-checks])
@@ -67,9 +67,21 @@ AX_AM_CFLAGS_ADD([-Werror=alloca])
 AX_AM_CFLAGS_ADD([-Werror=missing-field-initializers])
 AX_AM_CFLAGS_ADD([-Werror=format-signedness])
 AX_AM_CFLAGS_ADD([-fvisibility=hidden])
+AX_AM_CFLAGS_ADD([-D_FORTIFY_SOURCE=2])
+AX_AM_CFLAGS_ADD([-fstack-protector-strong])
+AX_AM_CFLAGS_ADD([-fPIE])
+AX_AM_CFLAGS_ADD([-fPIC -shared])
+
+# Add linker flags.
+AC_DEFUN([AX_AM_LDFLAGS_ADD],[AX_CHECK_LINK_FLAG($1, AM_LDFLAGS="$AM_LDFLAGS $1")])
+AX_AM_LDFLAGS_ADD([-pie])
+AX_AM_LDFLAGS_ADD([[-Wl,-z,relro]])
+AX_AM_LDFLAGS_ADD([[-Wl,-z,now]])
+AX_AM_LDFLAGS_ADD([[-Wl,-z,noexecstack]])
 
 AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_CPPFLAGS])
+AC_SUBST([AM_LDFLAGS])
 AC_PREFIX_DEFAULT(/usr)
 
 # Automake 1.11 - silent build rules
@@ -167,6 +179,7 @@ $PACKAGE_NAME $VERSION configuration:
   Source code location:    ${srcdir}
   Preprocessor flags:      ${AM_CPPFLAGS} ${CPPFLAGS}
   C compiler flags:        ${AM_CFLAGS} ${CFLAGS}
+  Linker flags:            ${AM_LDFLAGS} ${LDFLAGS}
   Common install location: ${prefix}
   configure parameters:    --enable-systemd=${SYSTEMD_STR} --enable-library=${with_library} --enable-test=${with_test} --enable-doc=${with_doc}
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -77,9 +77,16 @@ AX_AM_LDFLAGS_ADD([[-Wl,-z,relro]])
 AX_AM_LDFLAGS_ADD([[-Wl,-z,now]])
 AX_AM_LDFLAGS_ADD([[-Wl,-z,noexecstack]])
 
+# Add library compiler flags.
+AM_LIB_CFLAGS=''
+AC_DEFUN([AX_AM_LIB_CFLAGS_ADD],[AX_CHECK_COMPILE_FLAG($1, AM_LIB_CFLAGS="$AM_LIB_CFLAGS $1")])
+AX_AM_LIB_CFLAGS_ADD([-fPIC -shared])
+AX_AM_LIB_CFLAGS_ADD([-fvisibility=hidden])
+
 AC_SUBST([AM_CFLAGS])
 AC_SUBST([AM_CPPFLAGS])
 AC_SUBST([AM_LDFLAGS])
+AC_SUBST([AM_LIB_CFLAGS])
 AC_PREFIX_DEFAULT(/usr)
 
 # Automake 1.11 - silent build rules

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -20,4 +20,4 @@
 noinst_LTLIBRARIES = libcommon.la
 libcommon_la_SOURCES = config_file.h config_file.c
 libcommon_la_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src -I$(top_srcdir)/config \
-        $(AM_CFLAGS) $(LIBPCI_CFLAGS)
+        $(AM_CFLAGS) $(AM_LIB_CFLAGS) $(LIBPCI_CFLAGS)

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -33,7 +33,7 @@ noinst_LTLIBRARIES = libledinternal.la
 libledinternal_la_SOURCES = libled.c $(LIB_SRCS)
 libledinternal_la_LIBADD = $(LIBPCI_LIBS) ../common/libcommon.la
 libledinternal_la_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src \
-        -I$(top_srcdir)/config $(AM_CFLAGS) $(AM_LIB_CFLAGS)  $(LIBPCI_CFLAGS)
+        -I$(top_srcdir)/config $(AM_CFLAGS) $(AM_LIB_CFLAGS) $(LIBPCI_CFLAGS)
 
 # User may not want the shared library
 if WITH_LIBRARY

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -18,9 +18,6 @@
 
 SUBDIRS = include
 
-AM_LIB_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src -I$(top_srcdir)/config \
-        -fPIC -shared -fvisibility=hidden
-
 LIB_SRCS         = ahci.c block.c cntrl.c enclosure.c utils.c list.c \
                    raid.c scsi.c slave.c sysfs.c smp.c dellssd.c \
                    pci_slot.c vmdssd.c amd.c amd_sgpio.c amd_ipmi.c\
@@ -35,7 +32,8 @@ LIB_SRCS         = ahci.c block.c cntrl.c enclosure.c utils.c list.c \
 noinst_LTLIBRARIES = libledinternal.la
 libledinternal_la_SOURCES = libled.c $(LIB_SRCS)
 libledinternal_la_LIBADD = $(LIBPCI_LIBS) ../common/libcommon.la
-libledinternal_la_CFLAGS = $(AM_CFLAGS) $(AM_LIB_CFLAGS) $(LIBPCI_CFLAGS)
+libledinternal_la_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src \
+        -I$(top_srcdir)/config $(AM_CFLAGS) $(AM_LIB_CFLAGS)  $(LIBPCI_CFLAGS)
 
 # User may not want the shared library
 if WITH_LIBRARY

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -18,6 +18,9 @@
 
 SUBDIRS = include
 
+AM_LIB_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src -I$(top_srcdir)/config \
+        -fPIC -shared -fvisibility=hidden
+
 LIB_SRCS         = ahci.c block.c cntrl.c enclosure.c utils.c list.c \
                    raid.c scsi.c slave.c sysfs.c smp.c dellssd.c \
                    pci_slot.c vmdssd.c amd.c amd_sgpio.c amd_ipmi.c\
@@ -32,8 +35,7 @@ LIB_SRCS         = ahci.c block.c cntrl.c enclosure.c utils.c list.c \
 noinst_LTLIBRARIES = libledinternal.la
 libledinternal_la_SOURCES = libled.c $(LIB_SRCS)
 libledinternal_la_LIBADD = $(LIBPCI_LIBS) ../common/libcommon.la
-libledinternal_la_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src \
-        -I$(top_srcdir)/config $(AM_CFLAGS) $(LIBPCI_CFLAGS)
+libledinternal_la_CFLAGS = $(AM_CFLAGS) $(AM_LIB_CFLAGS) $(LIBPCI_CFLAGS)
 
 # User may not want the shared library
 if WITH_LIBRARY

--- a/tests/lib_unit_test.c
+++ b/tests/lib_unit_test.c
@@ -170,7 +170,6 @@ START_TEST(test_list_slots)
 	struct led_slot_list *sl = NULL;
 	bool devices_found = false;
 	led_status_t status = led_slots_get(ctx, &sl);
-	const char *block_node;
 
 	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_slots_get %u", status);
 	if (status == LED_STATUS_SUCCESS) {

--- a/tests/lib_unit_test.c
+++ b/tests/lib_unit_test.c
@@ -105,12 +105,12 @@ void block_device_check(const char *path)
 		int errno_cpy = errno;
 
 		ck_assert_msg(rc == 0,
-				"stat failed for %s, errno: %s", block_dev, strerror(errno_cpy));
+				"stat failed for %s, errno: %s", path, strerror(errno_cpy));
 		return;
 	}
 
 	ck_assert_msg((block_dev.st_mode & S_IFMT) == S_IFBLK,
-			"Expecting block device 0x%x block_dev.st_mode");
+			"Expecting block device 0x%x", block_dev.st_mode);
 }
 
 START_TEST(test_load_unload)


### PR DESCRIPTION
It is essential to avoid buffer overflows and similar bugs as much as possible.

Add AX_CHECK_LINK_FLAG macro usage witch requires `autoconf-archive` package to be installed.

Add compiler flags:
-D_FORTIFY_SOURCE - Compile-time protection against static sized buffer overflows,
-fstack-protector-strong - Adds stack canaries to functions as safety checks against stack overwrites,
-fPIE - Enables an ELF binary executable to be position independent,
-fPIC - Ensures that shared object code that is built into shared libraries should be position independent code,.

Add linker flags:
-pie - works together with gcc flag fPIE- please see its description,
-z,relro - A security measure which makes some binary sections read-only,
-z,now - Immediate Binding (Bindnow),
-z,noexecstack - Prevents stack from being executable.

Add 'autoconf-archive' package dependency to github workflows.
This package is requied by githab actions.

Fix compilation warnings.
