### PR TITLE
ahci, dellssd: silence not-supported messages

### DIFF
--- a/src/lib/ahci.c
+++ b/src/lib/ahci.c
@@ -90,7 +90,7 @@ int ahci_sgpio_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 	if (ibpi2val->ibpi == LED_IBPI_PATTERN_UNKNOWN) {
 		char buf[IPBI2STR_BUFF_SIZE];
 
-		lib_log(device->cntrl->ctx, LED_LOG_LEVEL_ERROR,
+		lib_log(device->cntrl->ctx, LED_LOG_LEVEL_INFO,
 			"AHCI: Controller doesn't support %s pattern\n",
 			ibpi2str(ibpi, buf, sizeof(buf)));
 		__set_errno_and_return(ERANGE);

--- a/src/lib/dellssd.c
+++ b/src/lib/dellssd.c
@@ -256,7 +256,7 @@ int dellssd_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 	if (ibpi2val->ibpi == LED_IBPI_PATTERN_UNKNOWN) {
 		char buf[IPBI2STR_BUFF_SIZE];
 
-		lib_log(device->cntrl->ctx, LED_LOG_LEVEL_ERROR,
+		lib_log(device->cntrl->ctx, LED_LOG_LEVEL_INFO,
 			"SSD: Controller doesn't support %s pattern\n",
 			ibpi2str(ibpi, buf, sizeof(buf)));
 		__set_errno_and_return(EINVAL);


### PR DESCRIPTION
Align the implementation with other controller types to avoid unexpected errors