### PR TITLE
Add '--disable-doc' option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,12 @@ if SYSTEMD_CONDITION
   OPTIONAL_SUBDIR = systemd
 endif
 
-SUBDIRS = doc src $(OPTIONAL_SUBDIR) tests
+if WITH_DOC
+  DOC_SUBDIR = doc
+  dist_doc_DATA = README.md
+endif
+
+SUBDIRS = src $(DOC_SUBDIR) $(OPTIONAL_SUBDIR) tests
 EXTRA_DIST = \
 	config/config.h \
 	systemd/ledmon.service.in \
@@ -34,8 +39,6 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = ledmon.pc
 
 endif
-
-dist_doc_DATA = README.md
 
 if WITH_TEST
 TESTS = tests/runtests.sh

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Run `./configure` with:
 Run `./configure` with:
     `--enable-test` to enable building unit tests and add target for `make check`
 
+Run `./configure` with:
+    `--disable-doc` to disable building documentation.
+
 ## 3. Compiling the package
 
 -------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,15 @@ AC_ARG_ENABLE([library],
 
 AM_CONDITIONAL([WITH_LIBRARY], [test "x$with_library" = "xyes"])
 
+# Add configure option to disable documentation building
+AC_ARG_ENABLE([doc],
+    [AS_HELP_STRING([--disable-doc],
+        [do not install ledmon documentation])],
+    [with_doc=${enableval}],
+    [with_doc=yes])
+
+AM_CONDITIONAL([WITH_DOC], [test "x$with_doc" = "xyes"])
+
 AC_CONFIG_FILES([Makefile
                  ledmon.pc
                  doc/Makefile
@@ -156,5 +165,5 @@ $PACKAGE_NAME $VERSION configuration:
   Preprocessor flags:      ${AM_CPPFLAGS} ${CPPFLAGS}
   C compiler flags:        ${AM_CFLAGS} ${CFLAGS}
   Common install location: ${prefix}
-  configure parameters:    --enable-systemd=${SYSTEMD_STR} --enable-library=${with_library} --enable-test=${with_test}
+  configure parameters:    --enable-systemd=${SYSTEMD_STR} --enable-library=${with_library} --enable-test=${with_test} --enable-doc=${with_doc}
 ])


### PR DESCRIPTION
Introduce a configure option to disable documentation installation in case if it is not required.