### PR TITLE
Add locate & failure enum

### DIFF
--- a/doc/ledctl.pod
+++ b/doc/ledctl.pod
@@ -134,6 +134,10 @@ Turns Locate LED associated with the given device(s) on.
 
 Turns only Locate LED off.
 
+=item B<locate_and_failure>
+
+Turns Locate LED and Failure LED on.
+
 =item B<normal>
 
 Turns Status LED, Failure LED and Locate LED off.

--- a/src/ledctl/ledctl.c
+++ b/src/ledctl/ledctl.c
@@ -275,8 +275,9 @@ static void _ledctl_help(void)
 		  "Allows user to set ledctl verbose level in logs.");
 	printf("\nPatterns:\n"
 	       "\tCommon patterns are:\n"
-	       "\t\tlocate, locate_off, normal, off, degraded, rebuild,\n" ""
-	       "\t\tfailed_array, hotspare, pfa, failure, disk_failed\n"
+	       "\t\tlocate, locate_off, normal, off, degraded, rebuild,\n"
+	       "\t\tfailed_array, hotspare, pfa, failure, disk_failed,\n"
+	       "\t\tlocate_and_failure\n"
 	       "\tSES-2 only patterns:\n"
 	       "\t\tses_abort, ses_rebuild, ses_ifa, ses_ica, ses_cons_check,\n"
 	       "\t\tses_hotspare, ses_rsvd_dev, ses_ok, ses_ident, ses_rm,\n"
@@ -381,6 +382,8 @@ static struct ibpi_state *_ibpi_state_get(const char *name)
 	} else if ((strcmp(name, "failure") == 0) ||
 		   (strcmp(name, "disk_failed") == 0)) {
 		ibpi = LED_IBPI_PATTERN_FAILED_DRIVE;
+	} else if (strcmp(name, "locate_and_failure") == 0) {
+		ibpi = LED_IBPI_PATTERN_LOCATE_AND_FAILED_DRIVE;
 	} else if (strcmp(name, "ses_abort") == 0) {
 		ibpi = LED_SES_REQ_ABORT;
 	} else if (strcmp(name, "ses_rebuild") == 0) {

--- a/src/lib/include/led/libled.h
+++ b/src/lib/include/led/libled.h
@@ -241,6 +241,7 @@ enum led_ibpi_pattern {
 	LED_IBPI_PATTERN_LOCATE_OFF,
 	LED_IBPI_PATTERN_ADDED,
 	LED_IBPI_PATTERN_REMOVED,
+	LED_IBPI_PATTERN_LOCATE_AND_FAILED_DRIVE,
 	/*
 	 * Below are SES-2 codes. Note that by default most IBPI messages are
 	 * translated into SES when needed but SES codes can be added also.
@@ -264,6 +265,7 @@ enum led_ibpi_pattern {
 	LED_SES_REQ_DEV_OFF,
 	LED_SES_REQ_FAULT,
 	LED_SES_REQ_PRDFAIL,
+	LED_SES_REQ_IDENT_AND_FAULT,
 	led_ibpi_pattern_count,
 };
 

--- a/src/lib/ses.c
+++ b/src/lib/ses.c
@@ -217,6 +217,8 @@ static enum led_ibpi_pattern ibpi_to_ses(enum led_ibpi_pattern ibpi)
 		return LED_SES_REQ_HOSTSPARE;
 	case LED_IBPI_PATTERN_PFA:
 		return LED_SES_REQ_PRDFAIL;
+	case LED_IBPI_PATTERN_LOCATE_AND_FAILED_DRIVE:
+		return LED_SES_REQ_IDENT_AND_FAULT;
 	default:
 		return ibpi;
 	}
@@ -398,6 +400,10 @@ static int ses_set_message(enum led_ibpi_pattern ibpi, struct ses_slot_ctrl_elem
 	case LED_SES_REQ_PRDFAIL:
 		_set_prdfail(msg.b);
 		break;
+	case LED_SES_REQ_IDENT_AND_FAULT:
+		_set_ident(msg.b);
+		_set_fault(msg.b);
+		break;
 	default:
 		return 1;
 	}
@@ -475,12 +481,12 @@ static void get_led_status(struct ses_pages *sp, int idx, enum led_ibpi_pattern 
 
 	*led_status = LED_IBPI_PATTERN_NORMAL;
 
-	if (desc_element->b2 & 0x02) {
+	if ((desc_element->b2 & 0x02) && (desc_element->b3 & 0x60))
+		*led_status = LED_IBPI_PATTERN_LOCATE_AND_FAILED_DRIVE;
+	else if (desc_element->b2 & 0x02)
 		*led_status = LED_IBPI_PATTERN_LOCATE;
-	}
-	if (desc_element->b3 & 0x60) {
+	else if (desc_element->b3 & 0x60)
 		*led_status = LED_IBPI_PATTERN_FAILED_DRIVE;
-	}
 }
 
 int ses_get_slots(struct ses_pages *sp, struct ses_slot **out_slots, int *out_slots_count)

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -716,7 +716,8 @@ const char *ibpi_str[led_ibpi_pattern_count] = {
 	[LED_IBPI_PATTERN_LOCATE]         = "LOCATE",
 	[LED_IBPI_PATTERN_LOCATE_OFF]     = "LOCATE_OFF",
 	[LED_IBPI_PATTERN_ADDED]          = "ADDED",
-	[LED_IBPI_PATTERN_REMOVED]        = "REMOVED"
+	[LED_IBPI_PATTERN_REMOVED]        = "REMOVED",
+	[LED_IBPI_PATTERN_LOCATE_AND_FAILED_DRIVE] = "LOCATE_AND_FAILURE"
 };
 
 const char *ibpi2str_table(enum led_ibpi_pattern ibpi, const char *names[], char *buf,


### PR DESCRIPTION
SES can have more than 1 LED that can be set per slot (IDENT and FAULT). Allow this to be retrieved and set.