### PR TITLE
Fix passing gcc flags in makefiles

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,7 +17,7 @@ jobs:
     name: Compilation test with gcc
     strategy:
       matrix:
-        gcc-version: [7, 8, 9, 10, 11, 12]
+        gcc-version: [7, 8, 9, 10, 11, 12, 13]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AC_DEFUN([AX_AM_CFLAGS_ADD],[AX_CHECK_COMPILE_FLAG($1, AM_CFLAGS="$AM_CFLAGS $1"
 AX_AM_CFLAGS_ADD([-Wformat -Werror=format-security])
 AX_AM_CFLAGS_ADD([-Werror=format-overflow=2])
 AX_AM_CFLAGS_ADD([-Wno-strict-overflow])
-AX_AM_CFLAGS_ADD([-Wno-delete-null-pointer-checks])
+AX_AM_CFLAGS_ADD([-fno-delete-null-pointer-checks])
 AX_AM_CFLAGS_ADD([-Wwrapv])
 AX_AM_CFLAGS_ADD([-Werror=format-truncation=1])
 AX_AM_CFLAGS_ADD([-Werror=shift-negative-value])

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -16,9 +16,8 @@
 #  51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-AM_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src -I$(top_srcdir)/config
-
 # Make a convenience library for this code
 noinst_LTLIBRARIES = libcommon.la
 libcommon_la_SOURCES = config_file.h config_file.c
-libcommon_la_CFLAGS = $(AM_CFLAGS) $(LIBPCI_CFLAGS)
+libcommon_la_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src -I$(top_srcdir)/config \
+        $(AM_CFLAGS) $(LIBPCI_CFLAGS)

--- a/src/ledctl/Makefile.am
+++ b/src/ledctl/Makefile.am
@@ -16,10 +16,9 @@
 #  51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-AM_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src -I$(top_srcdir)/config -I$(top_srcdir)/src/lib
-
 sbin_PROGRAMS  = ledctl
 ledctl_SOURCES = ledctl.c
 
 ledctl_LDADD = ../lib/libledinternal.la ../common/libcommon.la
-ledctl_CFLAGS = $(AM_CFLAGS)
+ledctl_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src -I$(top_srcdir)/config \
+        -I$(top_srcdir)/src/lib $(AM_CFLAGS)

--- a/src/ledmon/Makefile.am
+++ b/src/ledmon/Makefile.am
@@ -16,10 +16,9 @@
 #  51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
-AM_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src -I$(top_srcdir)/config -I$(top_srcdir)/src/lib
-
 sbin_PROGRAMS  = ledmon
 
 ledmon_SOURCES = ledmon.c pidfile.h pidfile.c udev.c udev.h
 ledmon_LDADD = ../lib/libledinternal.la ../common/libcommon.la $(LIBUDEV_LIBS)
-ledmon_CFLAGS = $(AM_CFLAGS) $(LIBUDEV_CFLAGS)
+ledmon_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src -I$(top_srcdir)/config \
+        -I$(top_srcdir)/src/lib $(AM_CFLAGS) $(LIBUDEV_CFLAGS)

--- a/src/ledmon/ledmon.c
+++ b/src/ledmon/ledmon.c
@@ -948,7 +948,7 @@ int main(int argc, char *argv[])
 
 	lib_rc = led_new(&ctx);
 	if (lib_rc != LED_STATUS_SUCCESS) {
-		fprintf(stderr, "Unable to initialize lib LED %d\n", lib_rc);
+		fprintf(stderr, "Unable to initialize lib LED %u\n", lib_rc);
 		return lib_rc;
 	}
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -18,8 +18,6 @@
 
 SUBDIRS = include
 
-AM_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src -I$(top_srcdir)/config
-
 LIB_SRCS         = ahci.c block.c cntrl.c enclosure.c utils.c list.c \
                    raid.c scsi.c slave.c sysfs.c smp.c dellssd.c \
                    pci_slot.c vmdssd.c amd.c amd_sgpio.c amd_ipmi.c\
@@ -34,7 +32,8 @@ LIB_SRCS         = ahci.c block.c cntrl.c enclosure.c utils.c list.c \
 noinst_LTLIBRARIES = libledinternal.la
 libledinternal_la_SOURCES = libled.c $(LIB_SRCS)
 libledinternal_la_LIBADD = $(LIBPCI_LIBS) ../common/libcommon.la
-libledinternal_la_CFLAGS = $(AM_CFLAGS) $(LIBPCI_CFLAGS)
+libledinternal_la_CFLAGS = -I$(top_srcdir)/src/lib/include -I$(top_srcdir)/src \
+        -I$(top_srcdir)/config $(AM_CFLAGS) $(LIBPCI_CFLAGS)
 
 # User may not want the shared library
 if WITH_LIBRARY

--- a/src/lib/include/led/libled.h
+++ b/src/lib/include/led/libled.h
@@ -332,7 +332,8 @@ led_status_t LED_SYM_PUBLIC led_device_name_lookup(const char *name, char *norma
  * @return enum led_cntrl_type which indicates which controller supports this device path,
  *		LED_CNTRL_TYPE_UNKNOWN if not supported
  */
-enum led_cntrl_type led_is_management_supported(struct led_ctx *ctx, const char *path);
+enum led_cntrl_type LED_SYM_PUBLIC led_is_management_supported(struct led_ctx *ctx,
+							       const char *path);
 
 /**
  * @brief Set the ibpi pattern for the specified device

--- a/src/lib/scsi.c
+++ b/src/lib/scsi.c
@@ -154,6 +154,10 @@ int scsi_ses_flush_enclosure(struct enclosure_device *enclosure)
 
 	ret = ses_send_diag(fd, &enclosure->ses_pages);
 	close(fd);
+
+	if (ret)
+		return ret;
+
 	return enclosure_reload(enclosure);
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@ if WITH_TEST
 all: lib_unit_test
 
 check_PROGRAMS = lib_unit_test
-lib_unit_test_CFLAGS = $(LIBCHECK_CFLAGS)
+lib_unit_test_CFLAGS = $(AM_CFLAGS) $(LIBCHECK_CFLAGS)
 lib_unit_test_LDADD = ../src/lib/libled.la $(LIBCHECK_LIBS)
 lib_unit_test_SOURCES = lib_unit_test.c
 endif

--- a/tests/lib_unit_test.c
+++ b/tests/lib_unit_test.c
@@ -96,13 +96,13 @@ START_TEST(test_load_unload)
 	struct led_ctx *lctx = NULL;
 	led_status_t status = led_new(&lctx);
 
-	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_new = %d", status);
+	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_new = %u", status);
 
 	status = led_scan(lctx);
-	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_scan = %d", status);
+	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_scan = %u", status);
 
 	status = led_free(lctx);
-	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_free = %d", status);
+	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_free = %u", status);
 }
 END_TEST
 
@@ -112,7 +112,7 @@ START_TEST(test_list_controllers)
 	struct led_cntrl_list *cl = NULL;
 	led_status_t status = led_cntrls_get(ctx, &cl);
 
-	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_cntrls_get %d", status);
+	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_cntrls_get %u", status);
 	bool devices_found = false;
 
 	if (status == LED_STATUS_SUCCESS) {
@@ -123,7 +123,7 @@ START_TEST(test_list_controllers)
 			enum led_cntrl_type t = led_cntrl_type(ce);
 
 			devices_found = true;
-			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %d cntrl type", t);
+			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %u cntrl type", t);
 		}
 
 		led_cntrl_list_reset(cl);
@@ -131,7 +131,7 @@ START_TEST(test_list_controllers)
 			ck_assert_msg(led_cntrl_path(ce) != NULL, "led_cntrl_path returned NULL");
 			enum led_cntrl_type t = led_cntrl_type(ce);
 
-			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %d cntrl type", t);
+			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %u cntrl type", t);
 		}
 
 		led_cntrl_list_free(cl);
@@ -148,7 +148,7 @@ START_TEST(test_list_slots)
 	bool devices_found = false;
 	led_status_t status = led_slots_get(ctx, &sl);
 
-	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_slots_get %d", status);
+	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_slots_get %u", status);
 	if (status == LED_STATUS_SUCCESS) {
 		struct led_slot_list_entry *se;
 
@@ -156,7 +156,7 @@ START_TEST(test_list_slots)
 			ck_assert_msg(led_slot_id(se) != NULL, "led_slot_id returned NULL");
 			enum led_cntrl_type t = led_slot_cntrl(se);
 
-			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %d cntrl type", t);
+			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %u cntrl type", t);
 			devices_found = true;
 			// TODO: Check led ibpi pattern and validate
 		}
@@ -166,7 +166,7 @@ START_TEST(test_list_slots)
 			ck_assert_msg(led_slot_id(se) != NULL, "led_slot_id returned NULL");
 			enum led_cntrl_type t = led_slot_cntrl(se);
 
-			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %d cntrl type", t);
+			ck_assert_msg(((int)t >= 1 && (int)t <= 6),  "invalid %u cntrl type", t);
 			// TODO: Check led ibpi pattern and validate
 		}
 
@@ -184,7 +184,7 @@ START_TEST(test_toggle_slots)
 	bool devices_found = false;
 	led_status_t status = led_slots_get(ctx, &sl);
 
-	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_slots_get %d", status);
+	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_slots_get %u", status);
 	if (status == LED_STATUS_SUCCESS) {
 		struct led_slot_list_entry *se;
 
@@ -198,11 +198,11 @@ START_TEST(test_toggle_slots)
 				status = led_slot_set(ctx, se, led);
 				devices_found = true;
 				ck_assert_msg(status == LED_STATUS_SUCCESS,
-						"led_slot_set %d", status);
+						"led_slot_set %u", status);
 				enum led_ibpi_pattern after_set = led_slot_state(se);
 
 				ck_assert_msg(led == after_set,
-						"%s led_slot_state expected = (%d) != actual (%d)",
+						"%s led_slot_state expected = (%u) != actual (%u)",
 						led_slot_id(se), led, after_set);
 			}
 		}
@@ -220,7 +220,7 @@ START_TEST(test_led_by_path)
 	bool devices_found = false;
 	led_status_t status = led_slots_get(ctx, &sl);
 
-	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_slots_get %d", status);
+	ck_assert_msg(status == LED_STATUS_SUCCESS, "led_slots_get %u", status);
 	if (status == LED_STATUS_SUCCESS) {
 		struct led_slot_list_entry *se;
 
@@ -235,7 +235,7 @@ START_TEST(test_led_by_path)
 
 				status = led_device_name_lookup(device_node, normalized);
 				ck_assert_msg(status == LED_STATUS_SUCCESS,
-						"led_device_name_lookup %d", status);
+						"led_device_name_lookup %u", status);
 				if (status != LED_STATUS_SUCCESS)
 					return;
 
@@ -250,7 +250,7 @@ START_TEST(test_led_by_path)
 					LED_IBPI_PATTERN_LOCATE : LED_IBPI_PATTERN_NORMAL;
 
 				status = led_set(ctx, normalized, expected);
-				ck_assert_msg(status == LED_STATUS_SUCCESS, "led_set %d", status);
+				ck_assert_msg(status == LED_STATUS_SUCCESS, "led_set %u", status);
 				if (status != LED_STATUS_SUCCESS)
 					return;
 
@@ -259,7 +259,7 @@ START_TEST(test_led_by_path)
 				led_via_slot = led_slot_state(se);
 
 				ck_assert_msg(expected == led_via_slot,
-						"Retrieved state %d != %d expected",
+						"Retrieved state %u != %u expected",
 						led_via_slot, expected);
 				if (expected != led_via_slot)
 					return;

--- a/tests/lib_unit_test.c
+++ b/tests/lib_unit_test.c
@@ -25,12 +25,12 @@ void setup(void)
 	led_status_t status = led_new(&ctx);
 
 	if (status != LED_STATUS_SUCCESS) {
-		printf("%s: led_new %d", __func__, status);
+		printf("%s: led_new %u", __func__, status);
 		exit(EXIT_FAILURE);
 	}
 	status = led_scan(ctx);
 	if (status != LED_STATUS_SUCCESS) {
-		printf("%s: led_scan %d", __func__, status);
+		printf("%s: led_scan %u", __func__, status);
 		exit(EXIT_FAILURE);
 	}
 }
@@ -40,7 +40,7 @@ void teardown(void)
 	led_status_t status = led_free(ctx);
 
 	if (status != LED_STATUS_SUCCESS) {
-		printf("%s: led_free %d", __func__, status);
+		printf("%s: led_free %u", __func__, status);
 		exit(EXIT_FAILURE);
 	}
 }
@@ -49,7 +49,6 @@ void setup_device_filters(void)
 {
 	int num_filters = 0;
 	char *found = NULL;
-	char *t = NULL;
 	char *tmp_filters = getenv("LEDMONTEST_SLOT_FILTER");
 
 	if (tmp_filters) {


### PR DESCRIPTION
Old solution overrides AM_CFLAGS variable.

Fix compilation warnings.

Add gcc 13 to CI in case to catch compilation warnings on newer gcc.