### PR TITLE
utils: Change match_string parameters

### DIFF
--- a/src/lib/cntrl.c
+++ b/src/lib/cntrl.c
@@ -390,7 +390,7 @@ struct cntrl_device *cntrl_device_init(const char *path, struct led_ctx *ctx)
 			char *cntrl = NULL;
 
 			list_for_each(&ctx->config.allowlist, cntrl) {
-				if (match_string(cntrl, path))
+				if (match_string(ctx, cntrl, path))
 					break;
 				cntrl = NULL;
 			}
@@ -403,7 +403,7 @@ struct cntrl_device *cntrl_device_init(const char *path, struct led_ctx *ctx)
 			char *cntrl;
 
 			list_for_each(&ctx->config.excludelist, cntrl) {
-				if (match_string(cntrl, path)) {
+				if (match_string(ctx, cntrl, path)) {
 					lib_log(ctx, LED_LOG_LEVEL_DEBUG,
 						"%s found on EXCLUDELIST, ignoring", path);
 					return NULL;

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -47,6 +47,8 @@
 #include "status.h"
 #include "utils.h"
 
+#include <lib/libled_internal.h>
+
 /**
  */
 #define TIMESTAMP_PATTERN    "%b %d %T "
@@ -483,7 +485,9 @@ int match_string(struct led_ctx *ctx, const char *string, const char *pattern)
 
 	status = regcomp(&regex, pattern, REG_EXTENDED);
 	if (status != 0) {
-		lib_log(ctx, LED_LOG_LEVEL_ERROR, "regecomp failed, ret=%d", status);
+		lib_log(ctx, LED_LOG_LEVEL_ERROR,
+			"Failed to initialize regular expression pattern (%s), regcomp ret=%d",
+			pattern, status);
 		return 0;
 	}
 

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -470,7 +470,7 @@ char *get_path_hostN(const char *path)
 	return s;
 }
 
-int match_string(const char *string, const char *pattern)
+int match_string(struct led_ctx *ctx, const char *string, const char *pattern)
 {
 	int status;
 	regex_t regex;
@@ -483,7 +483,7 @@ int match_string(const char *string, const char *pattern)
 
 	status = regcomp(&regex, pattern, REG_EXTENDED);
 	if (status != 0) {
-		printf("regecomp failed, ret=%d", status);
+		lib_log(ctx, LED_LOG_LEVEL_ERROR, "regecomp failed, ret=%d", status);
 		return 0;
 	}
 

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -438,7 +438,7 @@ int str_toui(unsigned int *dest, const char *strptr, char **endptr, int base);
  */
 char *get_path_hostN(const char *path);
 
-int match_string(const char *string, const char *pattern);
+int match_string(struct led_ctx *ctx, const char *string, const char *pattern);
 
 /**
  */


### PR DESCRIPTION
The function match_string was calling printf when regcomp returns and error.  As this function is being called from library code we cannot have it printing to stdout.  Add library context so that we can log this to the file descriptor that is associated with the library.