### PR TITLE
Fix a bunch of spelling mistakes in comments

### DIFF
--- a/src/lib/smp.h
+++ b/src/lib/smp.h
@@ -53,7 +53,7 @@
 #define GPIO_REG_IND_TX_0		0x00
 #define GPIO_REG_IND_TX_1		0x01
 
-#define SG_RESPONSE_TIMEOUT (5 * 1000)	/* 1000 as miliseconds multiplier */
+#define SG_RESPONSE_TIMEOUT (5 * 1000)	/* 1000 as milliseconds multiplier */
 #define SCSI_MAX_CDB_LENGTH	0x10
 
 #define GPIO_STATUS_OK			0x00


### PR DESCRIPTION
There are a few spelling mistakes in comments as found using codepspell. Fix these.