### PR TITLE
utils.c: Check snprintf return code

### DIFF
--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -71,16 +71,22 @@ struct log_level_info log_level_infos[] = {
 char *get_text(const char *path, const char *name)
 {
 	char temp[PATH_MAX];
+	int ret;
 
-	snprintf(temp, sizeof(temp), "%s/%s", path, name);
+	ret = snprintf(temp, sizeof(temp), "%s/%s", path, name);
+	if (ret < 0 || ret >= PATH_MAX)
+		return NULL;
 	return buf_read(temp);
 }
 
 char *get_text_to_dest(const char *path, const char *name, char *dest, size_t dest_len)
 {
 	char temp[PATH_MAX];
+	int ret;
 
-	snprintf(temp, sizeof(temp), "%s/%s", path, name);
+	ret = snprintf(temp, sizeof(temp), "%s/%s", path, name);
+	if (ret < 0 || ret >= PATH_MAX)
+		return NULL;
 	return buf_read_to_dest(temp, dest, dest_len);
 }
 


### PR DESCRIPTION
Fixes the compiler error I'm running into when building test packages on fedora.

```
In function 'get_text_to_dest',
    inlined from '_amd_sgpio_em_enabled' at ../lib/amd_sgpio.c:815:6,
    inlined from 'amd_em_enabled' at ../lib/amd.c:130:8,
    inlined from 'cntrl_device_init' at ../lib/cntrl.c:424:17,
    inlined from '_cntrl_add' at ../lib/sysfs.c:284:32,
    inlined from '_check_cntrl' at ../lib/sysfs.c:327:3:
../lib/utils.c:83:38: error: '%s' directive output may be truncated
    writing 20 bytes into a region of size between 0 and 4095
        [-Werror=format-truncation=]
   83 |         snprintf(temp, sizeof(temp), "%s/%s", path, name);
```

Test rpm packages: https://copr.fedorainfracloud.org/coprs/tasleson/ledmon-upstream/