### PR TITLE
Minimal nvme-multipath support

### DIFF
--- a/src/ledctl/ledctl.c
+++ b/src/ledctl/ledctl.c
@@ -483,7 +483,7 @@ bool _block_device_search(const struct list *block_list,
 static led_status_t _ibpi_state_add_block(struct ibpi_state *state, char *name)
 {
 	char path[PATH_MAX];
-	led_status_t rc = led_device_name_lookup(name, path);
+	led_status_t rc = led_device_name_lookup(ctx, name, path);
 
 	if (rc != LED_STATUS_SUCCESS)
 		return rc;

--- a/src/lib/block.h
+++ b/src/lib/block.h
@@ -73,6 +73,12 @@ struct block_device {
 	char *sysfs_path;
 
 /**
+ * Main devnode we can reach this device. It may not match /sys/dev/block/MAJ:MIN
+ * Could be empty.
+ */
+	char devnode[PATH_MAX];
+
+/**
  * The pointer to a function which sends a message to driver in order to
  * control LEDs in an enclosure or DAS system - @see send_message_t for details.
  * This field cannot have NULL pointer assigned.

--- a/src/lib/include/led/libled.h
+++ b/src/lib/include/led/libled.h
@@ -326,13 +326,15 @@ led_status_t LED_SYM_PUBLIC led_scan(struct led_ctx *ctx);
  * @brief Used to lookup a block device node to name used by library.  This function should be
  * called with its output being used as input for functions: led_is_management_supported, led_set.
  *
+ * @param[in]	ctx			Library context
  * @param[in]	name			Device node to lookup
  * @param[out]	normalized_name		Normalized device name, size >= PATH_MAX
  * @return led_status_t LED_STATUS_SUCCESS on success, else error reason.
  *
  * Note: both parameters are expected to have a size of PATH_MAX
  */
-led_status_t LED_SYM_PUBLIC led_device_name_lookup(const char *name, char *normalized_name);
+led_status_t LED_SYM_PUBLIC led_device_name_lookup(struct led_ctx *ctx, const char *name,
+						   char *normalized_name);
 
 /**
  * @brief Given a block device path, returns if it has LED hardware support via library

--- a/src/lib/slot.c
+++ b/src/lib/slot.c
@@ -39,9 +39,11 @@ struct slot_property *find_slot_by_device_name(struct led_ctx *ctx, char *device
 	list_for_each(sysfs_get_slots(ctx), slot) {
 		if (slot->c->cntrl_type != cntrl_type)
 			continue;
-		if (slot->bl_device == NULL)
+
+		if (!slot->bl_device || slot->bl_device->devnode[0] == 0)
 			continue;
-		if (strncmp(basename(slot->bl_device->sysfs_path),
+
+		if (strncmp(basename(slot->bl_device->devnode),
 			    basename(device_name), PATH_MAX) == 0)
 			return slot;
 	}

--- a/src/lib/sysfs.c
+++ b/src/lib/sysfs.c
@@ -48,12 +48,9 @@
 #include "vmdssd.h"
 #include "libled_private.h"
 
-/**
- */
 #define SYSFS_CLASS_BLOCK       "/sys/block"
 #define SYSFS_CLASS_ENCLOSURE   "/sys/class/enclosure"
 #define SYSFS_PCI_SLOTS         "/sys/bus/pci/slots"
-
 
 /**
  * @brief Determine device type.

--- a/src/lib/sysfs.h
+++ b/src/lib/sysfs.h
@@ -25,7 +25,9 @@
 #include "list.h"
 #include "status.h"
 
-#define SYSFS_PCI_DEVICES       "/sys/bus/pci/devices"
+#define SYSFS_PCI_DEVICES	"/sys/bus/pci/devices"
+
+#define SYSTEM_DEV_DIR		"/dev"
 
 struct sysfs {
 	/**

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -131,8 +131,15 @@ int get_int(const char *path, int defval, const char *name)
 	return defval;
 }
 
-/**
- */
+bool is_subpath(const char * const path, const char * const subpath, size_t subpath_strlen)
+{
+	assert(path && subpath);
+
+	if (strncmp(path, subpath, subpath_strlen) == 0)
+		return true;
+	return false;
+}
+
 int scan_dir(const char *path, struct list *result)
 {
 	struct dirent *dirent;

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -187,6 +187,17 @@ char *get_text_to_dest(const char *path, const char *name, char *dest, size_t de
 int get_bool(const char *path, int defval, const char *name);
 
 /**
+ * @brief Check if path contains subpath, starting from beginning.
+ *
+ * @param[in]      path           Path to check.
+ * @param[in]      subpath        Expected subpath.
+ * @param[in]      subpath_strlen Subpath string length.
+ *
+ * @return True if subpath is included on path, False otherwise.
+ */
+bool is_subpath(const char * const path, const char * const subpath, size_t subpath_strlen);
+
+/**
  * @brief Writes a text to file.
  *
  * This function writes a text to a file and return the number of bytes written.

--- a/tests/ledctl/slot_test.py
+++ b/tests/ledctl/slot_test.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2023 Red Hat Inc.
 
-# The purpose of this file is testing interractions with hardware. Tests are projected
+# The purpose of this file is testing interactions with hardware. Tests are projected
 # to be executed only if possible (required hardware is available).
 # Ledctl support many blinking standards, there is no possibility to test them all at once.
 # We parametrize each test by controller type to gather logs confirming that it was run

--- a/tests/ledctl/slot_test.py
+++ b/tests/ledctl/slot_test.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2023 Red Hat Inc.
 
-# Simple tests for ledctl.  This needs to be expanded.
+# The purpose of this file is testing interractions with hardware. Tests are projected
+# to be executed only if possible (required hardware is available).
+# Ledctl support many blinking standards, there is no possibility to test them all at once.
+# We parametrize each test by controller type to gather logs confirming that it was run
+# on appropriative hardware.
+# Collecting such results will be benefitable for release stuff, it gives some creditability that it
+# was minimally tested.
 
 import pytest
 import logging
@@ -9,37 +15,103 @@ from ledctl_cmd import LedctlCmd
 
 LOGGER = logging.getLogger(__name__)
 
-def test_non_slot_set_path(ledctl_binary, slot_filters, controller_filters):
+def get_slots_with_device_or_skip(cmd: LedctlCmd, cntrl):
+    try:
+        slots_with_device_node = cmd.get_slots_with_device(cntrl)
+    except AssertionError as e:
+        pytest.skip(str(e))
+
+    if len(slots_with_device_node) == 0:
+        pytest.skip("No slot with device found")
+    return slots_with_device_node
+
+@pytest.mark.parametrize("cntrl", LedctlCmd.slot_mgmt_ctrls)
+def test_ibpi(ledctl_binary, slot_filters, controller_filters, cntrl):
     """
-    Test setting the led status by using non-slot syntax, eg. ledctl locate=/dev/sda
+    Test setting the led status by using IBPI syntax for the disk under the chosen controller.
+    Limited to controllers with slots feature support.
     """
 
     cmd = LedctlCmd(ledctl_binary, slot_filters, controller_filters)
-    slots_with_device_nodes = [s for s in cmd.get_all_slots() if s.device_node is not None]
+    slots_with_device_node = get_slots_with_device_or_skip(cmd, cntrl)
 
-    if len(slots_with_device_nodes) == 0:
-        pytest.skip("This test requires slots with devices but none found.")
-
-    for slot in slots_with_device_nodes:
-        for state in ["failure", "locate", "normal"]:
+    for slot in slots_with_device_node:
+        for state in LedctlCmd.base_states:
             cmd.set_ibpi(slot.device_node, state)
             cur = cmd.get_slot(slot)
             assert cur.state == state,\
-                f"unable to set from \"{slot}\" to \"{state}\", current = \"{cur}\" using non-slot syntax"
+                f"unable to set \"{slot.device_node}\" to \"{state}\", current = \"{cur}\" using ibpi syntax"
 
-def test_slot_state_walk(ledctl_binary, slot_filters, controller_filters):
+@pytest.mark.parametrize("cntrl", LedctlCmd.slot_mgmt_ctrls)
+def test_set_slot_by_slot(ledctl_binary, slot_filters, controller_filters, cntrl):
     """
-    Test that we can set slots to different states and verify that they reported a change
+    Test that we can set slots to different states and verify that they reported a change, using --slot.
     """
 
     cmd = LedctlCmd(ledctl_binary, slot_filters, controller_filters)
-    slots = cmd.get_all_slots()
+    try:
+        slots = [s for s in cmd.get_slots(cntrl)]
+    except AssertionError as e:
+        pytest.skip(str(e))
 
     if len(slots) == 0:
-        pytest.skip("This test requires any slot but none found.")
+        pytest.skip("No slot found")
 
     for slot in slots:
-        for state in ["locate", "failure", "normal"]:
+        for state in LedctlCmd.base_states:
             cmd.set_slot_state(slot, state)
             cur = cmd.get_slot(slot)
-            assert cur.state == state, f"unable to set from \"{slot}\" to \"{state}\", current = \"{cur}\""
+            assert cur.state == state,\
+                f"unable to set \"{slot}\" to \"{state}\", current = \"{cur}\" using slot"
+
+def slot_set_and_get_by_device_all(cmd: LedctlCmd, slot):
+        for state in LedctlCmd.base_states:
+            cmd.set_device_state(slot, state)
+            cur = cmd.get_slot_by_device(slot)
+            assert cur.state == state,\
+                f"unable to set \"{slot}\" to \"{state}\", current = \"{cur}\" using --device"
+
+@pytest.mark.parametrize("cntrl", LedctlCmd.slot_mgmt_ctrls)
+def test_set_slot_by_device(ledctl_binary, slot_filters, controller_filters, cntrl):
+    """
+    Test that we can set slots to different states and verify that they reported a change, using device.
+    """
+
+    cmd = LedctlCmd(ledctl_binary, slot_filters, controller_filters)
+    slots_with_device_node = get_slots_with_device_or_skip(cmd, cntrl)
+
+    for slot in slots_with_device_node:
+        slot_set_and_get_by_device_all(cmd, slot)
+
+@pytest.mark.parametrize("cntrl", ["VMD", "NPEM"])
+def test_nvme_multipath_drives(ledctl_binary, slot_filters, controller_filters, cntrl):
+    """
+    Special test for multipath drives using both set methods and get via device. We need to check
+    if ledctl provides nvme multipath minimal support.
+    """
+    cmd = LedctlCmd(ledctl_binary, slot_filters, controller_filters)
+
+    mp_drives = cmd.get_mp_nodes()
+    if len(mp_drives) == 0:
+        pytest.skip("No nvme multipath drives found")
+
+    slots_with_device_node = get_slots_with_device_or_skip(cmd, cntrl)
+    any_found = False
+
+    for slot in slots_with_device_node:
+        if slot.device_node not in mp_drives:
+                continue
+        any_found = True
+
+        LOGGER.debug(f"Found nvme multipath drive {slot}")
+
+        for state in cmd.base_states:
+            cmd.set_ibpi(slot.device_node, state)
+            cur = cmd.get_slot_by_device(slot)
+            assert cur.state == state,\
+                f"unable to set \"{slot}\" to \"{state}\", current = \"{cur}\" using ibpi syntax"
+
+        slot_set_and_get_by_device_all(cmd, slot)
+
+    if not any_found:
+        pytest.skip("Multipath drives are not connected to tested controller")

--- a/tests/lib_unit_test.c
+++ b/tests/lib_unit_test.c
@@ -260,7 +260,7 @@ START_TEST(test_led_by_path)
 				enum led_ibpi_pattern led_via_slot;
 				enum led_ibpi_pattern expected;
 
-				status = led_device_name_lookup(device_node, normalized);
+				status = led_device_name_lookup(ctx, device_node, normalized);
 				ck_assert_msg(status == LED_STATUS_SUCCESS,
 						"led_device_name_lookup %u", status);
 				if (status != LED_STATUS_SUCCESS)


### PR DESCRIPTION
nvme support with tests.

Slot tests has been divided into parametrized method by the controller to achieve more detailed results.
Now it shows the controller under test. It simplifies analysis.

Example output:

```
# pytest tests/ledctl/slot_test.py
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.11.2, pytest-7.4.3, pluggy-1.3.0
rootdir: /root/ledmon-mtkaczyk
configfile: pytest.ini
collecting ...
----------------------------------------------------------------------------------- live log collection ------------------------------------------------------------------------------------
INFO     conftest:conftest.py:18 [CONFIG] --ledctl-binary: src/ledctl/ledctl
INFO     conftest:conftest.py:18 [CONFIG] --slot-filters: none
INFO     conftest:conftest.py:18 [CONFIG] --controller-filters: none
collected 11 items

tests/ledctl/slot_test.py::test_ibpi[ledctl_binary0-slot_filters0-controller_filters0-SCSI] SKIPPED (No slot with device found)                                                      [  9%]
tests/ledctl/slot_test.py::test_ibpi[ledctl_binary0-slot_filters0-controller_filters0-VMD] FAILED                                                                                    [ 18%]
tests/ledctl/slot_test.py::test_ibpi[ledctl_binary0-slot_filters0-controller_filters0-NPEM] PASSED                                                                                   [ 27%]
tests/ledctl/slot_test.py::test_set_slot_by_slot[ledctl_binary0-slot_filters0-controller_filters0-SCSI] SKIPPED (No slot found)                                                      [ 36%]
tests/ledctl/slot_test.py::test_set_slot_by_slot[ledctl_binary0-slot_filters0-controller_filters0-VMD] PASSED                                                                        [ 45%]
tests/ledctl/slot_test.py::test_set_slot_by_slot[ledctl_binary0-slot_filters0-controller_filters0-NPEM] PASSED                                                                       [ 54%]
tests/ledctl/slot_test.py::test_set_slot_by_device[ledctl_binary0-slot_filters0-controller_filters0-SCSI] SKIPPED (No slot with device found)                                        [ 63%]
tests/ledctl/slot_test.py::test_set_slot_by_device[ledctl_binary0-slot_filters0-controller_filters0-VMD] PASSED                                                                      [ 72%]
tests/ledctl/slot_test.py::test_set_slot_by_device[ledctl_binary0-slot_filters0-controller_filters0-NPEM] PASSED                                                                     [ 81%]
tests/ledctl/slot_test.py::test_nvme_multipath_drives[ledctl_binary0-slot_filters0-controller_filters0-VMD] PASSED                                                                   [ 90%]
tests/ledctl/slot_test.py::test_nvme_multipath_drives[ledctl_binary0-slot_filters0-controller_filters0-NPEM] SKIPPED (Multipath drives are not connected to tested controller)       [100%]
```
Failed scenario is connected with: #189 - on the platform used NPEM is best choose but VMD is checked.
Deprecates: #167 
Closes: #150 