### PR TITLE
ipmi.c: Fix off by 1 memset

### DIFF
--- a/src/lib/ipmi.c
+++ b/src/lib/ipmi.c
@@ -61,11 +61,11 @@ static int ipmi_open(void)
 int ipmicmd(struct led_ctx *ctx, int sa, int lun, int netfn, int cmd, int datalen, void *data,
 	    int resplen, int *rlen, void *resp)
 {
-	struct ipmi_system_interface_addr saddr;
-	struct ipmi_ipmb_addr iaddr;
-	struct ipmi_addr raddr;
-	struct ipmi_req req;
-	struct ipmi_recv rcv;
+	struct ipmi_system_interface_addr saddr = {0};
+	struct ipmi_ipmb_addr iaddr = {0};
+	struct ipmi_addr raddr = {0};
+	struct ipmi_req req = {0};
+	struct ipmi_recv rcv = {0};
 	fd_set rfd;
 	int fd, rc;
 	uint8_t tresp[resplen + 1];
@@ -74,12 +74,7 @@ int ipmicmd(struct led_ctx *ctx, int sa, int lun, int netfn, int cmd, int datale
 	if (fd < 0)
 		return -1;
 
-	memset(&saddr, 0, sizeof(saddr));
-	memset(&iaddr, 0, sizeof(iaddr));
-	memset(&raddr, 0, sizeof(raddr));
-	memset(&req, 0, sizeof(req));
-	memset(&rcv, 0, sizeof(rcv));
-	memset(tresp, 0, sizeof(uint8_t) + (resplen + 1));
+	memset(tresp, 0, sizeof(tresp));
 
 	if (sa == BMC_SA) {
 		saddr.addr_type = IPMI_SYSTEM_INTERFACE_ADDR_TYPE;


### PR DESCRIPTION
The code was using the size of an element + number of elements
for the memset which is incorrect.  It should be the size of an
element * the number of elements.  However, as we are simply
clearing memory for an array on the stack, a simple sizeof
array will give us what we need, which is the number of bytes
the array occupies.

This was discovered as a SIGABORT on Fedora 38 testing of
pre-released compiled library package.

Note: replaced memsets for structs with struct initialization
syntax as requested in review comments.


```
*** buffer overflow detected ***: terminated

Program received signal SIGABRT, Aborted.
0x00007ffff7e0a884 in __pthread_kill_implementation () from /lib64/libc.so.6
Missing separate debuginfos, use: dnf debuginfo-install glibc-2.37-14.fc38.x86_64
(gdb) bt
#0  0x00007ffff7e0a884 in __pthread_kill_implementation () from /lib64/libc.so.6
#1  0x00007ffff7db9afe in raise () from /lib64/libc.so.6
#2  0x00007ffff7da287f in abort () from /lib64/libc.so.6
#3  0x00007ffff7da360f in __libc_message.cold () from /lib64/libc.so.6
#4  0x00007ffff7e9e969 in __fortify_fail () from /lib64/libc.so.6
#5  0x00007ffff7e9d1a4 in __chk_fail () from /lib64/libc.so.6
#6  0x00007ffff7fb7789 in memset (__len=22, __ch=0, __dest=0x7fffffffaf60) at /usr/include/bits/string_fortified.h:59
#7  ipmicmd (ctx=ctx@entry=0x4052a0, sa=sa@entry=32, lun=lun@entry=0, netfn=netfn@entry=6, cmd=cmd@entry=89, datalen=datalen@entry=4, data=<optimized out>, resplen=<optimized out>, rlen=<optimized out>, resp=<optimized out>) at /home/tasleson/ledmon/src/lib/ipmi.c:82
#8  0x00007ffff7fb7b3d in get_dell_server_type (ctx=ctx@entry=0x4052a0) at /home/tasleson/ledmon/src/lib/dellssd.c:119
#9  0x00007ffff7fb7f07 in _is_dellssd_cntrl (ctx=0x4052a0, path=0x7fffffffb280 "/sys/devices/pci0000:00/0000:00:02.0/0000:0c:00.0") at /home/tasleson/ledmon/src/lib/cntrl.c:148
#10 _get_type (ctx=0x4052a0, path=0x7fffffffb280 "/sys/devices/pci0000:00/0000:00:02.0/0000:0c:00.0") at /home/tasleson/ledmon/src/lib/cntrl.c:218
#11 cntrl_device_init (ctx=0x4052a0, path=0x7fffffffb280 "/sys/devices/pci0000:00/0000:00:02.0/0000:0c:00.0") at /home/tasleson/ledmon/src/lib/cntrl.c:387
#12 _cntrl_add (path=0x7fffffffb280 "/sys/devices/pci0000:00/0000:00:02.0/0000:0c:00.0", ctx=0x4052a0) at /home/tasleson/ledmon/src/lib/sysfs.c:284
#13 _check_cntrl (ctx=ctx@entry=0x4052a0, path=<optimized out>) at /home/tasleson/ledmon/src/lib/sysfs.c:327
#14 0x00007ffff7fb9d49 in _scan_cntrl (ctx=0x4052a0) at /home/tasleson/ledmon/src/lib/sysfs.c:370
#15 sysfs_scan (ctx=0x4052a0) at /home/tasleson/ledmon/src/lib/sysfs.c:592
#16 led_scan (ctx=0x4052a0) at /home/tasleson/ledmon/src/lib/libled.c:96
#17 0x000000000040129b in main () at list_slots.c:29


```