### PR TITLE
Fix exit ledctl with test flag.

### DIFF
--- a/src/ledctl/ledctl.c
+++ b/src/ledctl/ledctl.c
@@ -1156,7 +1156,8 @@ int main(int argc, char *argv[])
 
 	status = _cmdline_parse(argc, argv, &req);
 	if (status != LED_STATUS_SUCCESS || test_params) {
-		print_configuration();
+		if (test_params)
+			print_configuration();
 		exit(status);
 	}
 


### PR DESCRIPTION
When mode in ledctl was started with test flag,
the corrected block ends the program and
prints the configuration,
this message should not be printed when the program is run in normal mode.