### PR TITLE
Fix running pytests with empty slot-filters

### DIFF
--- a/tests/ledctl/ledctl_cmd.py
+++ b/tests/ledctl/ledctl_cmd.py
@@ -119,6 +119,8 @@ class LedctlCmd:
             return False
 
         for slot_filter in self.slot_filters:
+            if not slot_filter:
+                return False
             if slot.slot.startswith(slot_filter):
                 # Filter out this slot
                 return True


### PR DESCRIPTION
Add checking if slot_filter is not empty, otherwise all devices will be filted out when running tests with empty filters:
 _--slot-filters=""_ and finally test result is SKIPPED.

To reproduce issue please run tests using command:
pytest tests --ledctl-binary=src/ledctl/ledctl --slot-filters=""