### PR TITLE
Add struct for mapping ibpi statuses to strings.

### DIFF
--- a/src/ledmon/ledmon.c
+++ b/src/ledmon/ledmon.c
@@ -114,28 +114,6 @@ static char *ledmon_conf_path;
 static int foreground;
 
 /**
- * @brief Name of IBPI patterns.
- *
- * This is internal array with names of IBPI patterns. Logging routines use this
- * entries to translate enumeration type into the string.
- */
-const char *ibpi_str_ledmon[] = {
-	[LED_IBPI_PATTERN_UNKNOWN]        = "None",
-	[LED_IBPI_PATTERN_NORMAL]         = "Off",
-	[LED_IBPI_PATTERN_ONESHOT_NORMAL] = "Oneshot Off",
-	[LED_IBPI_PATTERN_DEGRADED]       = "In a Critical Array",
-	[LED_IBPI_PATTERN_REBUILD]        = "Rebuild",
-	[LED_IBPI_PATTERN_FAILED_ARRAY]   = "In a Failed Array",
-	[LED_IBPI_PATTERN_HOTSPARE]       = "Hotspare",
-	[LED_IBPI_PATTERN_PFA]            = "Predicted Failure Analysis",
-	[LED_IBPI_PATTERN_FAILED_DRIVE]   = "Failure",
-	[LED_IBPI_PATTERN_LOCATE]         = "Locate",
-	[LED_IBPI_PATTERN_LOCATE_OFF]     = "Locate Off",
-	[LED_IBPI_PATTERN_ADDED]          = "Added",
-	[LED_IBPI_PATTERN_REMOVED]        = "Removed"
-};
-
-/**
  * Internal variable of monitor service. It is the pattern used to print out
  * information about the version of monitor service.
  */
@@ -680,7 +658,6 @@ static void _handle_fail_state(struct block_device *block,
 static void _add_block(struct block_device *block)
 {
 	struct block_device *temp = NULL;
-	char buf[IPBI2STR_BUFF_SIZE];
 
 	list_for_each(&ledmon_block_list, temp) {
 		if (block_compare(temp, block))
@@ -715,12 +692,10 @@ static void _add_block(struct block_device *block)
 
 		_handle_fail_state(block, temp);
 
-		if (ibpi != temp->ibpi && ibpi <= LED_IBPI_PATTERN_REMOVED) {
-			log_info("CHANGE %s: from '%s' to '%s'.",
-				 temp->sysfs_path,
-				 ibpi2str_table(ibpi, ibpi_str_ledmon, buf, sizeof(buf)),
-				 ibpi2str_table(temp->ibpi, ibpi_str_ledmon, buf, sizeof(buf)));
-		}
+		if (ibpi != temp->ibpi && ibpi <= LED_IBPI_PATTERN_REMOVED)
+			log_info("CHANGE %s: from '%s' to '%s'", temp->sysfs_path, ibpi2str(ibpi),
+				 ibpi2str(temp->ibpi));
+
 		/* Check if name of the device changed.*/
 		if (strcmp(temp->sysfs_path, block->sysfs_path)) {
 			log_info("NAME CHANGED %s to %s",
@@ -736,8 +711,8 @@ static void _add_block(struct block_device *block)
 		/* Device not found, it's a new one! */
 		temp = block_device_duplicate(block);
 		if (temp != NULL) {
-			log_info("NEW %s: state '%s'.", temp->sysfs_path,
-				 ibpi2str_table(temp->ibpi, ibpi_str_ledmon, buf, sizeof(buf)));
+			log_info("NEW %s: state '%s'.", temp->sysfs_path, ibpi2str(temp->ibpi));
+
 			if (!list_append(&ledmon_block_list, temp)) {
 				log_error("Memory allocation error!");
 				exit(1);
@@ -763,7 +738,6 @@ static void _add_block(struct block_device *block)
  */
 static void _send_msg(struct block_device *block)
 {
-	char buf[IPBI2STR_BUFF_SIZE];
 	if (!block->cntrl) {
 		log_debug("Missing cntrl for dev: %s. Not sending anything.",
 			  strstr(block->sysfs_path, "host"));
@@ -772,11 +746,9 @@ static void _send_msg(struct block_device *block)
 	if (block->timestamp != timestamp ||
 	    block->ibpi == LED_IBPI_PATTERN_REMOVED) {
 		if (block->ibpi != LED_IBPI_PATTERN_FAILED_DRIVE) {
-			log_info("CHANGE %s: from '%s' to '%s'.",
-				 block->sysfs_path,
-				 ibpi2str_table(block->ibpi, ibpi_str_ledmon, buf, sizeof(buf)),
-				 ibpi2str_table(LED_IBPI_PATTERN_FAILED_DRIVE, ibpi_str_ledmon,
-						buf, sizeof(buf)));
+			log_info("CHANGE %s: from '%s' to '%s'.", block->sysfs_path,
+				 ibpi2str(block->ibpi), ibpi2str(LED_IBPI_PATTERN_FAILED_DRIVE));
+
 			block->ibpi = LED_IBPI_PATTERN_FAILED_DRIVE;
 		} else {
 			char *host = strstr(block->sysfs_path, "host");

--- a/src/lib/ahci.c
+++ b/src/lib/ahci.c
@@ -88,11 +88,9 @@ int ahci_sgpio_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 	ibpi2val = get_by_ibpi(ibpi, ibpi2sgpio, ARRAY_SIZE(ibpi2sgpio));
 
 	if (ibpi2val->ibpi == LED_IBPI_PATTERN_UNKNOWN) {
-		char buf[IPBI2STR_BUFF_SIZE];
-
 		lib_log(device->cntrl->ctx, LED_LOG_LEVEL_INFO,
-			"AHCI: Controller doesn't support %s pattern\n",
-			ibpi2str(ibpi, buf, sizeof(buf)));
+			"AHCI: Controller doesn't support %s pattern\n", ibpi2str(ibpi));
+
 		__set_errno_and_return(ERANGE);
 	}
 

--- a/src/lib/amd_ipmi.c
+++ b/src/lib/amd_ipmi.c
@@ -369,19 +369,17 @@ static int _enable_smbus_control(struct amd_drive *drive)
 
 static int _change_ibpi_state(struct amd_drive *drive, enum led_ibpi_pattern ibpi, bool enable)
 {
-	char buf[IPBI2STR_BUFF_SIZE];
 	const struct ibpi2value *ibpi2val = get_by_ibpi(ibpi, ibpi2amd_ipmi,
 							ARRAY_SIZE(ibpi2amd_ipmi));
 
 	if (ibpi2val->ibpi == LED_IBPI_PATTERN_UNKNOWN) {
 		lib_log(drive->ctx, LED_LOG_LEVEL_INFO,
-			"AMD_IPMI: Controller doesn't support %s pattern\n",
-			ibpi2str(ibpi, buf, sizeof(buf)));
+			"AMD_IPMI: Controller doesn't support %s pattern\n", ibpi2str(ibpi));
 		return LED_STATUS_INVALID_STATE;
 	}
 
-	lib_log(drive->ctx, LED_LOG_LEVEL_DEBUG, "%s %s LED\n",
-		(enable) ? "Enabling":"Disabling", ibpi2str(ibpi, buf, sizeof(buf)));
+	lib_log(drive->ctx, LED_LOG_LEVEL_DEBUG, "%s %s LED\n", (enable) ? "Enabling" : "Disabling",
+		ibpi2str(ibpi));
 
 	return _set_ipmi_register(enable, ibpi2val->value, drive);
 }
@@ -442,14 +440,12 @@ int _amd_ipmi_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 {
 	int rc;
 	struct amd_drive drive;
-	char buf[IPBI2STR_BUFF_SIZE];
 
 	memset(&drive, 0, sizeof(struct amd_drive));
 	drive.ctx = device->cntrl->ctx;
 
 	lib_log(drive.ctx, LED_LOG_LEVEL_INFO, "\n");
-	lib_log(drive.ctx, LED_LOG_LEVEL_INFO, "Setting %s...",
-		ibpi2str(ibpi, buf, sizeof(buf)));
+	lib_log(drive.ctx, LED_LOG_LEVEL_INFO, "Setting %s...", ibpi2str(ibpi));
 
 	rc = _get_amd_ipmi_drive(device->cntrl_path, &drive);
 	if (rc)

--- a/src/lib/amd_sgpio.c
+++ b/src/lib/amd_sgpio.c
@@ -624,14 +624,12 @@ static int _set_ibpi(struct block_device *device, enum led_ibpi_pattern ibpi)
 	struct transmit_register tx_reg;
 	struct cache_entry *cache;
 	struct cache_entry cache_dup;
-	char buf[IPBI2STR_BUFF_SIZE];
 
 	memset(&drive, 0, sizeof(struct amd_drive));
 	drive.ctx = device->cntrl->ctx;
 
 	lib_log(drive.ctx, LED_LOG_LEVEL_INFO, "\n");
-	lib_log(drive.ctx, LED_LOG_LEVEL_INFO, "Setting %s...",
-		ibpi2str(ibpi, buf, sizeof(buf)));
+	lib_log(drive.ctx, LED_LOG_LEVEL_INFO, "Setting %s...", ibpi2str(ibpi));
 	lib_log(drive.ctx, LED_LOG_LEVEL_DEBUG, "\tdevice: ...%s",
 		strstr(device->sysfs_path, "/ata"));
 	lib_log(drive.ctx, LED_LOG_LEVEL_DEBUG, "\tbuffer: ...%s",

--- a/src/lib/dellssd.c
+++ b/src/lib/dellssd.c
@@ -254,11 +254,9 @@ int dellssd_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 	ibpi2val = get_by_ibpi(ibpi, ibpi2ssd, ARRAY_SIZE(ibpi2ssd));
 
 	if (ibpi2val->ibpi == LED_IBPI_PATTERN_UNKNOWN) {
-		char buf[IPBI2STR_BUFF_SIZE];
 
 		lib_log(device->cntrl->ctx, LED_LOG_LEVEL_INFO,
-			"SSD: Controller doesn't support %s pattern\n",
-			ibpi2str(ibpi, buf, sizeof(buf)));
+			"SSD: Controller doesn't support %s pattern\n", ibpi2str(ibpi));
 		__set_errno_and_return(EINVAL);
 	}
 

--- a/src/lib/include/led/libled.h
+++ b/src/lib/include/led/libled.h
@@ -224,7 +224,7 @@ enum led_ibpi_pattern {
 	LED_IBPI_PATTERN_LOCATE_OFF = 11,
 	LED_IBPI_PATTERN_ADDED = 12,
 	LED_IBPI_PATTERN_REMOVED = 13,
-	LED_IBPI_PATTERN_LOCATE_AND_FAILED_DRIVE = 14,
+	LED_IBPI_PATTERN_LOCATE_AND_FAIL = 14,
 	/*
 	 * Below are SES-2 codes. Note that by default most IBPI messages are
 	 * translated into SES when needed but SES codes can be added also.

--- a/src/lib/npem.c
+++ b/src/lib/npem.c
@@ -237,7 +237,6 @@ status_t npem_set_slot(struct led_ctx *ctx, const char *sysfs_path, enum led_ibp
 	struct pci_dev *pdev = NULL;
 	struct pci_access *pacc = get_pci_access();
 	const struct ibpi2value *ibpi2val;
-	char buf[IPBI2STR_BUFF_SIZE];
 
 	u32 val;
 	u32 reg;
@@ -248,8 +247,7 @@ status_t npem_set_slot(struct led_ctx *ctx, const char *sysfs_path, enum led_ibp
 
 	if (ibpi2val->ibpi == LED_IBPI_PATTERN_UNKNOWN) {
 		lib_log(ctx, LED_LOG_LEVEL_INFO,
-			"NPEM: Controller doesn't support %s pattern\n",
-			ibpi2str(state, buf, sizeof(buf)));
+			"NPEM: Controller doesn't support %s pattern\n", ibpi2str(state));
 		return STATUS_INVALID_STATE;
 	}
 	cap = (u32)ibpi2val->value;
@@ -270,8 +268,8 @@ status_t npem_set_slot(struct led_ctx *ctx, const char *sysfs_path, enum led_ibp
 
 	if (!is_mask_set(pdev, PCI_NPEM_CAP_REG, cap)) {
 		lib_log(ctx, LED_LOG_LEVEL_INFO,
-			"NPEM: Controller %s doesn't support %s pattern\n",
-			sysfs_path, ibpi2str(state, buf, sizeof(buf)));
+			"NPEM: Controller %s doesn't support %s pattern\n", sysfs_path,
+			ibpi2str(state));
 		pci_free_dev(pdev);
 		pci_cleanup(pacc);
 		return STATUS_INVALID_STATE;

--- a/src/lib/ses.c
+++ b/src/lib/ses.c
@@ -217,7 +217,7 @@ static enum led_ibpi_pattern ibpi_to_ses(enum led_ibpi_pattern ibpi)
 		return LED_SES_REQ_HOTSPARE;
 	case LED_IBPI_PATTERN_PFA:
 		return LED_SES_REQ_PRDFAIL;
-	case LED_IBPI_PATTERN_LOCATE_AND_FAILED_DRIVE:
+	case LED_IBPI_PATTERN_LOCATE_AND_FAIL:
 		return LED_SES_REQ_IDENT_AND_FAULT;
 	default:
 		return ibpi;
@@ -482,7 +482,7 @@ static void get_led_status(struct ses_pages *sp, int idx, enum led_ibpi_pattern 
 	*led_status = LED_IBPI_PATTERN_NORMAL;
 
 	if ((desc_element->b2 & 0x02) && (desc_element->b3 & 0x60))
-		*led_status = LED_IBPI_PATTERN_LOCATE_AND_FAILED_DRIVE;
+		*led_status = LED_IBPI_PATTERN_LOCATE_AND_FAIL;
 	else if (desc_element->b2 & 0x02)
 		*led_status = LED_IBPI_PATTERN_LOCATE;
 	else if (desc_element->b3 & 0x60)

--- a/src/lib/smp.c
+++ b/src/lib/smp.c
@@ -452,16 +452,15 @@ int scsi_smp_fill_buffer(struct block_device *device, enum led_ibpi_pattern ibpi
 	}
 
 	if (device->cntrl->isci_present && !ibpi2sgpio[ibpi].support_mask) {
-		char buf[IPBI2STR_BUFF_SIZE];
 		char *c = strrchr(device->sysfs_path, '/');
+
 		if (c++) {
 			lib_log(device->cntrl->ctx, LED_LOG_LEVEL_DEBUG,
-				"pattern %s not supported for device (/dev/%s)",
-				ibpi2str(ibpi, buf, sizeof(buf)), c);
+				"pattern %s not supported for device (/dev/%s)", ibpi2str(ibpi), c);
 		} else {
 			lib_log(device->cntrl->ctx, LED_LOG_LEVEL_DEBUG,
-				"pattern %s not supported for device %s",
-				ibpi2str(ibpi, buf, sizeof(buf)), device->sysfs_path);
+				"pattern %s not supported for device %s", ibpi2str(ibpi),
+				device->sysfs_path);
 		}
 		__set_errno_and_return(ENOTSUP);
 	}

--- a/src/lib/sysfs.c
+++ b/src/lib/sysfs.c
@@ -472,13 +472,11 @@ static int _is_failed_array(struct raid_device *raid)
  */
 static void _set_block_state(struct block_device *block, enum led_ibpi_pattern ibpi)
 {
-	char buf[IPBI2STR_BUFF_SIZE];
 	char *debug_dev = strrchr(block->sysfs_path, '/');
 	debug_dev = debug_dev ? debug_dev + 1 : block->sysfs_path;
 
 	lib_log(block->cntrl->ctx, LED_LOG_LEVEL_DEBUG,
-		"(%s): device: %s, state: %s", __func__, debug_dev,
-		ibpi2str(ibpi, buf, sizeof(buf)));
+		"(%s): device: %s, state: %s", __func__, debug_dev, ibpi2str(ibpi));
 	if (block->ibpi < ibpi)
 		block->ibpi = ibpi;
 }

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -689,49 +689,98 @@ status_t set_verbose_level(struct ledmon_conf *conf, int log_level)
 }
 
 /**
- * @brief IBPI pattern names.
- *
- * This is internal array holding names of IBPI pattern. Logging routines use
- * this entries to translate enumeration type values into the string.
+ * @brief Mapping IBPI states to strings. There are 2 strings:
+ *        - logs, uppercase for readability, should be set for all patterns.
+ *        - user input, user friendly names, could not be set.
  */
-const char *ibpi_str[LED_IBPI_PATTERN_COUNT] = {
-	[LED_IBPI_PATTERN_UNKNOWN]        = "UNKNOWN",
-	[LED_IBPI_PATTERN_NORMAL]         = "NORMAL",
-	[LED_IBPI_PATTERN_ONESHOT_NORMAL] = "ONESHOT_NORMAL",
-	[LED_IBPI_PATTERN_DEGRADED]       = "ICA",
-	[LED_IBPI_PATTERN_REBUILD]        = "REBUILD",
-	[LED_IBPI_PATTERN_FAILED_ARRAY]   = "IFA",
-	[LED_IBPI_PATTERN_HOTSPARE]       = "HOTSPARE",
-	[LED_IBPI_PATTERN_PFA]            = "PFA",
-	[LED_IBPI_PATTERN_FAILED_DRIVE]   = "FAILURE",
-	[LED_IBPI_PATTERN_LOCATE]         = "LOCATE",
-	[LED_IBPI_PATTERN_LOCATE_OFF]     = "LOCATE_OFF",
-	[LED_IBPI_PATTERN_ADDED]          = "ADDED",
-	[LED_IBPI_PATTERN_REMOVED]        = "REMOVED",
-	[LED_IBPI_PATTERN_LOCATE_AND_FAILED_DRIVE] = "LOCATE_AND_FAILURE"
+struct ibpi2names {
+	enum led_ibpi_pattern ibpi;
+	char *log_name;
+	char *input_name;
 };
 
-const char *ibpi2str_table(enum led_ibpi_pattern ibpi, const char *names[], char *buf,
-			   size_t buf_size)
+const struct ibpi2names ipbi_names[] = {
+	{LED_IBPI_PATTERN_REBUILD,		"REBUILD",		"rebuild"},
+	{LED_IBPI_PATTERN_LOCATE,		"LOCATE",		"locate"},
+	{LED_IBPI_PATTERN_LOCATE_OFF,		"LOCATE_OFF",		"locate_off"},
+	{LED_IBPI_PATTERN_LOCATE_AND_FAIL,	"LOCATE_AND_FAIL",	"locate_and_failure"},
+	{LED_SES_REQ_ABORT,			"SES_ABORT",		"ses_abort"},
+	{LED_SES_REQ_REBUILD,			"SES_REBUILD",		"ses_rebuild"},
+	{LED_SES_REQ_IFA,			"SES_IFA",		"ses_ifa"},
+	{LED_SES_REQ_ICA,			"SES_ICA",		"ses_ica"},
+	{LED_SES_REQ_CONS_CHECK,		"SES_CONS_CHECK",	"ses_cons_check"},
+	{LED_SES_REQ_HOTSPARE,			"SES_HOTSPARE",		"ses_hotspare"},
+	{LED_SES_REQ_RSVD_DEV,			"SES_RSVD_DEV",		"ses_rsvd_dev"},
+	{LED_SES_REQ_OK,			"SES_OK",		"ses_ok"},
+	{LED_SES_REQ_IDENT,			"SES_IDENT",		"ses_ident"},
+	{LED_SES_REQ_RM,			"SES_RM",		"ses_rm"},
+	{LED_SES_REQ_INS,			"SES_INSERT",		"ses_insert"},
+	{LED_SES_REQ_MISSING,			"SES_MISSING",		"ses_missing"},
+	{LED_SES_REQ_DNR,			"SES_DNR",		"ses_dnr"},
+	{LED_SES_REQ_ACTIVE,			"SES_ACTIVE",		"ses_active"},
+	{LED_SES_REQ_EN_BB,			"SES_ENABLE_BB",	"ses_enable_bb"},
+	{LED_SES_REQ_EN_BA,			"SES_ENABLE_BA",	"ses_enable_ba"},
+	{LED_SES_REQ_DEV_OFF,			"SES_DEVOFF",		"ses_devoff"},
+	{LED_SES_REQ_FAULT,			"SES_FAULT",		"ses_fault"},
+	{LED_SES_REQ_PRDFAIL,			"SES_PRDFAIL",		"ses_prdfail"},
+
+	/* Special internal patterns, can be only printed */
+	{LED_IBPI_PATTERN_UNKNOWN,		"UNKNOWN",		NULL},
+	{LED_IBPI_PATTERN_ADDED,		"ADDED",		NULL},
+	{LED_IBPI_PATTERN_REMOVED,		"REMOVED",		NULL},
+	{LED_IBPI_PATTERN_ONESHOT_NORMAL,	"ONESHOT_NORMAL",	NULL},
+
+	/* Here comes IBPI states with multiple input names defined. */
+	{LED_IBPI_PATTERN_NORMAL,	"NORMAL",	"normal"},
+	{LED_IBPI_PATTERN_NORMAL,	"NORMAL",	"off"},
+
+	{LED_IBPI_PATTERN_DEGRADED,	"ICA",		"ica"},
+	{LED_IBPI_PATTERN_DEGRADED,	"ICA",		"degraded"},
+
+	{LED_IBPI_PATTERN_FAILED_ARRAY,	"IFA",		"ifa"},
+	{LED_IBPI_PATTERN_FAILED_ARRAY,	"IFA",		"failed_array"},
+
+	{LED_IBPI_PATTERN_HOTSPARE,	"HOTSPARE",	"hotspare"},
+	{LED_IBPI_PATTERN_PFA,		"PFA",		"pfa"},
+
+	{LED_IBPI_PATTERN_FAILED_DRIVE,	"FAILURE",	"failure"},
+	{LED_IBPI_PATTERN_FAILED_DRIVE,	"FAILURE",	"disk_failed"},
+
+	{LED_IBPI_PATTERN_COUNT,	"UNKNOWN",	NULL},
+};
+
+/**
+ * @brief Return log friendly IBPI pattern name.
+ *
+ * Every led_ibpi_pattern must be defined. Do not put pointer to free.
+ */
+const char *ibpi2str(enum led_ibpi_pattern ibpi)
 {
-	const char *ret;
+	int i;
 
-	if (ibpi >= 0 && ibpi < LED_IBPI_PATTERN_COUNT)
-		ret = names[ibpi];
-	else
-		ret = NULL;
+	for (i = 0; i < ARRAY_SIZE(ipbi_names); i++)
+		if (ipbi_names[i].ibpi == ibpi)
+			return ipbi_names[i].log_name;
 
-	if (!ret) {
-		snprintf(buf, buf_size, "(unknown: %u)", ibpi);
-		ret = buf;
-	}
-
-	return ret;
+	/* That should not happen */
+	assert(false);
 }
 
-const char *ibpi2str(enum led_ibpi_pattern ibpi, char *buf, size_t buf_size)
+enum led_ibpi_pattern string2ibpi(const char *name)
 {
-	return ibpi2str_table(ibpi, ibpi_str, buf, buf_size);
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(ipbi_names); i++) {
+		char *input_name = ipbi_names[i].input_name;
+
+		if (!input_name)
+			continue;
+
+		if (strncmp(input_name, name, strlen(input_name)) == 0)
+			return ipbi_names[i].ibpi;
+	}
+
+	return LED_IBPI_PATTERN_UNKNOWN;
 }
 
 static const struct ibpi2value *get_ibpi2value(const enum led_ibpi_pattern val,

--- a/src/lib/utils.h
+++ b/src/lib/utils.h
@@ -499,10 +499,8 @@ void setup_options(struct option **longopt, char **shortopt, int *options,
 int get_option_id(const char *optarg);
 status_t set_verbose_level(struct ledmon_conf *conf, int log_level);
 
-#define IPBI2STR_BUFF_SIZE 32
-const char *ibpi2str(enum led_ibpi_pattern ibpi, char *buf, size_t buf_size);
-const char *ibpi2str_table(enum led_ibpi_pattern ibpi, const char *names[], char *buf,
-			   size_t buf_size);
+const char *ibpi2str(enum led_ibpi_pattern ibpi);
+enum led_ibpi_pattern string2ibpi(const char *name);
 
 /**
  * @brief Returns ibpi2value entry if IBPI matches

--- a/src/lib/vmdssd.c
+++ b/src/lib/vmdssd.c
@@ -161,11 +161,9 @@ status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum led_ibpi_pattern
 
 	ibpi2val = get_by_ibpi(ibpi, ibpi_to_attention, ARRAY_SIZE(ibpi_to_attention));
 	if (ibpi2val->ibpi == LED_IBPI_PATTERN_UNKNOWN) {
-		char ibpi_buff[IPBI2STR_BUFF_SIZE];
 
 		lib_log(slot->ctx, LED_LOG_LEVEL_INFO,
-			"VMD: Controller doesn't support %s pattern\n",
-			ibpi2str(ibpi, ibpi_buff, sizeof(ibpi_buff)));
+			"VMD: Controller doesn't support %s pattern\n", ibpi2str(ibpi));
 		return STATUS_INVALID_STATE;
 	}
 	val = (uint16_t)ibpi2val->value;


### PR DESCRIPTION
This is done different way in multiple places. Add one structure to lib and make in commonly used. Differentiate input values and logged values, not all patterns can be set but all patterns should be logged.

This simplifies implementation, there is no need to handle temporary buf strings for generating "(unknown: %d)" messages.

Fixes #198 