### PR TITLE
ledctl: add error message for missing devices

### DIFF
--- a/src/ledctl/ledctl.c
+++ b/src/ledctl/ledctl.c
@@ -406,8 +406,10 @@ static led_status_t _ibpi_state_add_block(struct ibpi_state *state, char *name)
 	char path[PATH_MAX];
 	led_status_t rc = led_device_name_lookup(ctx, name, path);
 
-	if (rc != LED_STATUS_SUCCESS)
+	if (rc != LED_STATUS_SUCCESS) {
+		log_error("Could not find %s.", name);
 		return rc;
+	}
 
 	if (!led_is_management_supported(ctx, path)) {
 		log_error("%s: device not supported", name);

--- a/tests/ledctl/ledctl_cmd.py
+++ b/tests/ledctl/ledctl_cmd.py
@@ -68,6 +68,15 @@ class LedctlCmd:
         LOGGER.debug(f"Command returned:\n {result.stdout}")
         return result
 
+    # Run ledctl command and expect it to fail
+    def run_ledctl_cmd_not_valid(self, params: list):
+        result = self.run_ledctl_cmd(params, output=True)
+        if result.returncode == 0:
+            raise Exception("Command succeed, but was expected to fail!")
+
+        LOGGER.debug(f"Command returned:\n {result.stderr}")
+        return result
+
     # Ledctl Commands
 
     def set_slot_state(self, slot: Slot, state):

--- a/tests/ledctl/parameters_test.py
+++ b/tests/ledctl/parameters_test.py
@@ -175,3 +175,21 @@ def test_version(ledctl_binary, version_cmd):
     res = cmd.run_ledctl_cmd_valid(version_cmd.split()).stdout
     lines = res.split('\n')
     parse_version(lines)
+
+
+@pytest.mark.parametrize("nexist_dev", ["/dev/nvr_gon_giv_u_up"])
+# Check if proper message is returned for not existing device.
+def test_nexist_dev_output(ledctl_binary, nexist_dev):
+    cmd = LedctlCmd(ledctl_binary)
+    cmd.is_test_flag_enabled()
+    res = cmd.run_ledctl_cmd_not_valid(["locate={}".format(nexist_dev)])
+    assert "Could not find {}".format(nexist_dev) in res.stderr
+
+
+@pytest.mark.parametrize("unsprtd_dev", ["/dev/zero"])
+# Check if proper message is returned for unsupported device.
+def test_unsprtd_dev_output(ledctl_binary, unsprtd_dev):
+    cmd = LedctlCmd(ledctl_binary)
+    cmd.is_test_flag_enabled()
+    res = cmd.run_ledctl_cmd_not_valid(["locate={}".format(unsprtd_dev)])
+    assert "{}: device not supported".format(unsprtd_dev) in res.stderr

--- a/tests/ledctl/parameters_test.py
+++ b/tests/ledctl/parameters_test.py
@@ -73,7 +73,7 @@ def test_ibpi_parameters_are_valid_short_test_flag(ledctl_binary,
 def test_parameters_log_path(ledctl_binary, log_path_commands):
     cmd = LedctlCmd(ledctl_binary)
     cmd.is_test_flag_enabled()
-    output = cmd.run_ledctl_cmd_decode(log_path_commands.split())
+    output = cmd.run_ledctl_cmd_valid(log_path_commands.split()).stdout
     assert "LOG_PATH=/root/test.log" in output
 
 
@@ -83,10 +83,10 @@ def test_parameter_log_level_all_values(ledctl_binary):
     tested_log_levels = ["warning", "debug", "all", "info", "quiet", "error"]
     for level in tested_log_levels:
         args = "--list-controllers -T --log-level=" + level
-        output = cmd.run_ledctl_cmd_decode(args.split())
+        output = cmd.run_ledctl_cmd_valid(args.split()).stdout
         assert "LOG_LEVEL=" + level.upper() in output
         args = "--list-controllers -T --" + level
-        output = cmd.run_ledctl_cmd_decode(args.split())
+        output = cmd.run_ledctl_cmd_valid(args.split()).stdout
         assert "LOG_LEVEL=" + level.upper() in output
 
 
@@ -160,7 +160,7 @@ def parse_help(lines):
 def test_main_help(ledctl_binary, help_cmd):
     cmd = LedctlCmd(ledctl_binary)
     cmd.is_test_flag_enabled()
-    res = cmd.run_ledctl_cmd_decode(help_cmd.split())
+    res = cmd.run_ledctl_cmd_valid(help_cmd.split()).stdout
     lines = res.split('\n')
     parse_help(lines)
 
@@ -172,6 +172,6 @@ def test_main_help(ledctl_binary, help_cmd):
 def test_version(ledctl_binary, version_cmd):
     cmd = LedctlCmd(ledctl_binary)
     cmd.is_test_flag_enabled()
-    res = cmd.run_ledctl_cmd_decode(version_cmd.split())
+    res = cmd.run_ledctl_cmd_valid(version_cmd.split()).stdout
     lines = res.split('\n')
     parse_version(lines)


### PR DESCRIPTION
Ledctl prints error message for not supported devices, but there is no such message for not existent or missing devices.

Add error message for missing devices for consistency.