### PR TITLE
templates: Add link to required dependencies

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -11,6 +11,10 @@ body:
       It is an open-source project, so we highly encourage you to fix issue yourself
       and to become a contributor.
 
+      If the issue is submitted against compilation, please double check that all
+      dependencies listed [here](https://github.com/intel/ledmon?tab=readme-ov-file#1-dependencies)
+      are installed.
+
       Please enable highest log level when collecting logs, it could speed up investigation
       e.g. ledctl --log-level=all locate=/dev/nvme0n1
 


### PR DESCRIPTION
In case of compilation issue, suggest reporter checking required dependencies first.
In case if `autoconf-archive` package is missing, no direct error is printed (#218)

Hope someone will find it useful!
