### PR TITLE
Add dependabot action for gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add dependabot config to check updates of actions used in the repository. This option will cause dependabot to automatically issue PRs with actions updates.