### PR TITLE
src/ledctl/ledctl.c: replace on_exit by atexit

### DIFF
--- a/src/ledctl/ledctl.c
+++ b/src/ledctl/ledctl.c
@@ -230,7 +230,7 @@ static void ibpi_state_fini(struct ibpi_state *p)
  *
  * @return The function does not return a value.
  */
-static void _ledctl_fini(int _i, void *_arg)
+static void _ledctl_fini(void)
 {
 	led_free(ctx);
 	list_erase(&ibpi_list);
@@ -1101,7 +1101,7 @@ int main(int argc, char *argv[])
 	if (status != LED_STATUS_SUCCESS)
 		return status;
 
-	if (on_exit(_ledctl_fini, progname))
+	if (atexit(_ledctl_fini))
 		exit(LED_STATUS_ONEXIT_ERROR);
 
 	status = _read_shared_conf();


### PR DESCRIPTION
Replace `on_exit` by `atexit` to avoid the following musl build failure raised since https://github.com/intel/ledmon/commit/bcb90426a156fcb3147b5722ed78ac8cf26f2976 which partially reverted https://github.com/intel/ledmon/commit/f08dd2c7b978233f5074aa7991fa894270934391:

```
/home/buildroot/autobuild/instance-3/output-1/host/lib/gcc/arm-buildroot-linux-musleabi/12.3.0/../../../../arm-buildroot-linux-musleabi/bin/ld: ledctl-ledctl.o: in function `main':
ledctl.c:(.text.startup+0x140): undefined reference to `on_exit'
```

Fixes:
 - http://autobuild.buildroot.org/results/d535e03f6ee0f43ecea34fb29ea148a4cdc01169