### PR TITLE
Fix nitpicker action

### DIFF
--- a/.github/workflows/nitpicker.yaml
+++ b/.github/workflows/nitpicker.yaml
@@ -1,5 +1,5 @@
 name: Nitpicker
-on: [pull_request]
+on: [pull_request_target]
 permissions:
   pull-requests: write
 jobs:


### PR DESCRIPTION
pull_request workflow limits the permission of the action to read-only in case the PR comes from a public fork.

Change workflow to pull_request_target which allows to write to PR.