### PR TITLE
ledmon: change led pattern setting

### DIFF
--- a/src/ledmon/ledmon.c
+++ b/src/ledmon/ledmon.c
@@ -740,7 +740,7 @@ static void _send_msg(struct block_device *block)
 		}
 	}
 
-	status = block->send_fn(block, block->ibpi);
+	status = block->send_message_fn(block, block->ibpi);
 	if (status == STATUS_INVALID_STATE) {
 		switch (block->ibpi) {
 		/**
@@ -764,7 +764,7 @@ static void _send_msg(struct block_device *block)
 				 ibpi2str(block->ibpi), block->sysfs_path,
 				 ibpi2str(LED_IBPI_PATTERN_NORMAL));
 			block->ibpi = LED_IBPI_PATTERN_NORMAL;
-			status = block->send_fn(block, block->ibpi);
+			status = block->send_message_fn(block, block->ibpi);
 			break;
 		case LED_IBPI_PATTERN_ADDED:
 		case LED_IBPI_PATTERN_REMOVED:
@@ -790,7 +790,7 @@ static void _flush_msg(struct block_device *block)
 {
 	if (!block->cntrl)
 		return;
-	block->flush_fn(block);
+	block->flush_message_fn(block);
 }
 
 static void _revalidate_dev(struct block_device *block)

--- a/src/ledmon/ledmon.c
+++ b/src/ledmon/ledmon.c
@@ -719,6 +719,8 @@ static void _add_block(struct block_device *block)
  */
 static void _send_msg(struct block_device *block)
 {
+	status_t status;
+
 	if (!block->cntrl) {
 		log_debug("Missing cntrl for dev: %s. Not sending anything.",
 			  strstr(block->sysfs_path, "host"));
@@ -737,8 +739,51 @@ static void _send_msg(struct block_device *block)
 				  host ? host : block->sysfs_path);
 		}
 	}
-	block->send_fn(block, block->ibpi);
+
+	status = block->send_fn(block, block->ibpi);
+	if (status == STATUS_INVALID_STATE) {
+		switch (block->ibpi) {
+		/**
+		 * These two states are treated as neutral by ledmon. Therefore, do not display an
+		 * error message if the controller does not support them.
+		 */
+		case LED_IBPI_PATTERN_UNKNOWN:
+		case LED_IBPI_PATTERN_NONE:
+			status = STATUS_SUCCESS;
+			break;
+		/**
+		 * These states are imposed by ledmon but they are not commonly supported.
+		 * In case the controller does not support following statuses, ledmon will attempt
+		 * to reset state to normal. It is mandatory because it leads to misbehaviors during
+		 * BLINK_ON_MIGR or REBUILD_BLINK_ON_ALL config option switches in rebuild/migration
+		 * runtime.
+		 */
+		case LED_IBPI_PATTERN_DEGRADED:
+		case LED_IBPI_PATTERN_HOTSPARE:
+			log_info("Pattern %s not supported by controller on %s. Overwrite by %s.",
+				 ibpi2str(block->ibpi), block->sysfs_path,
+				 ibpi2str(LED_IBPI_PATTERN_NORMAL));
+			block->ibpi = LED_IBPI_PATTERN_NORMAL;
+			status = block->send_fn(block, block->ibpi);
+			break;
+		case LED_IBPI_PATTERN_ADDED:
+		case LED_IBPI_PATTERN_REMOVED:
+			log_info("Inappropiate IBPI LED status to set: %s on %s",
+				    ibpi2str(block->ibpi), block->sysfs_path);
+		default:
+			break;
+		}
+	}
+
+	/**
+	 * ibpi_prev is always updated regardless send_message_fn status. It works this way from
+	 * the beginning.
+	 */
 	block->ibpi_prev = block->ibpi;
+
+	if (status)
+		log_error("Unable to set %s IBPI state on %s. Status: %d",
+			  ibpi2str(block->ibpi), block->sysfs_path, status);
 }
 
 static void _flush_msg(struct block_device *block)

--- a/src/lib/ahci.h
+++ b/src/lib/ahci.h
@@ -30,9 +30,8 @@ char *ahci_get_port_path(const char *path);
  * @param[in]      ibpi           IBPI pattern to visualize on LEDs associated
  *                                with the given slot.
  *
- * @return Number of bytes send to controller, -1 means error occurred and
- *         errno has additional error information.
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-int ahci_sgpio_write(struct block_device *path, enum led_ibpi_pattern ibpi);
+status_t ahci_sgpio_write(struct block_device *path, enum led_ibpi_pattern ibpi);
 
 #endif				/* _AHCI_H_INCLUDED_ */

--- a/src/lib/amd.c
+++ b/src/lib/amd.c
@@ -127,30 +127,23 @@ int amd_em_enabled(const char *path, struct led_ctx *ctx)
 	return rc;
 }
 
-int amd_write(struct block_device *device, enum led_ibpi_pattern ibpi)
+status_t amd_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 {
-	int rc;
-
 	/* write only if state has changed */
 	if (ibpi == device->ibpi_prev)
-		return 1;
+		return STATUS_SUCCESS;
 
 	switch (amd_interface) {
 	case AMD_INTF_SGPIO:
-		rc = _amd_sgpio_write(device, ibpi);
-		break;
+		return _amd_sgpio_write(device, ibpi);
 	case AMD_INTF_IPMI:
-		rc = _amd_ipmi_write(device, ibpi);
-		break;
+		return _amd_ipmi_write(device, ibpi);
 	case AMD_INTF_UNSET:
 	default:
 		lib_log(device->cntrl->ctx, LED_LOG_LEVEL_ERROR,
 			"Unsupported AMD interface %u\n", amd_interface);
-		rc = -EOPNOTSUPP;
-		break;
+		return STATUS_FILE_WRITE_ERROR;
 	}
-
-	return rc;
 }
 
 char *amd_get_path(const char *cntrl_path, const char *sysfs_path, struct led_ctx *ctx)

--- a/src/lib/amd.h
+++ b/src/lib/amd.h
@@ -36,7 +36,7 @@ enum amd_ipmi_platforms {
 extern enum amd_ipmi_platforms amd_ipmi_platform;
 
 int amd_em_enabled(const char *path, struct led_ctx *ctx);
-int amd_write(struct block_device *device, enum led_ibpi_pattern ibpi);
+status_t amd_write(struct block_device *device, enum led_ibpi_pattern ibpi);
 char *amd_get_path(const char *cntrl_path, const char *sysfs_path, struct led_ctx *ctx);
 
 int _find_file_path(const char *start_path, const char *filename,

--- a/src/lib/amd_ipmi.h
+++ b/src/lib/amd_ipmi.h
@@ -6,5 +6,5 @@
 #include "block.h"
 
 int _amd_ipmi_em_enabled(const char *path, struct led_ctx *ctx);
-int _amd_ipmi_write(struct block_device *device, enum led_ibpi_pattern ibpi);
+status_t _amd_ipmi_write(struct block_device *device, enum led_ibpi_pattern ibpi);
 char *_amd_ipmi_get_path(const char *cntrl_path, const char *sysfs_path);

--- a/src/lib/amd_sgpio.c
+++ b/src/lib/amd_sgpio.c
@@ -833,20 +833,22 @@ int _amd_sgpio_em_enabled(const char *path, struct led_ctx *ctx)
 	return rc ? 0 : 1;
 }
 
-int _amd_sgpio_write(struct block_device *device, enum led_ibpi_pattern ibpi)
+status_t _amd_sgpio_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 {
 	/* write only if state has changed */
 	if (ibpi == device->ibpi_prev)
-		return 1;
+		return STATUS_SUCCESS;
 
 	if ((ibpi < LED_IBPI_PATTERN_NORMAL) || (ibpi > LED_IBPI_PATTERN_LOCATE_OFF))
-		__set_errno_and_return(ERANGE);
+		return STATUS_INVALID_STATE;
 
 	if ((ibpi == LED_IBPI_PATTERN_DEGRADED) ||
 	    (ibpi == LED_IBPI_PATTERN_FAILED_ARRAY))
-		__set_errno_and_return(ENOTSUP);
+		return STATUS_INVALID_STATE;
 
-	return _set_ibpi(device, ibpi);
+	if (_set_ibpi(device, ibpi))
+		return STATUS_FILE_WRITE_ERROR;
+	return STATUS_SUCCESS;
 }
 
 char *_amd_sgpio_get_path(const char *cntrl_path, struct led_ctx *ctx)

--- a/src/lib/amd_sgpio.h
+++ b/src/lib/amd_sgpio.h
@@ -27,7 +27,7 @@ struct cache_entry {
 } __attribute__ ((__packed__));
 
 int _amd_sgpio_em_enabled(const char *path, struct led_ctx *ctx);
-int _amd_sgpio_write(struct block_device *device, enum led_ibpi_pattern ibpi);
+status_t _amd_sgpio_write(struct block_device *device, enum led_ibpi_pattern ibpi);
 char *_amd_sgpio_get_path(const char *cntrl_path, struct led_ctx *ctx);
 
 void amd_sgpio_cache_free(struct led_ctx *ctx);

--- a/src/lib/block.h
+++ b/src/lib/block.h
@@ -17,29 +17,6 @@
 struct block_device;
 
 /**
- * @brief Pointer to a send message function.
- *
- * The pointer to a function which knows how to send LED message to a driver of
- * storage controller using the given protocol.
- *
- * @param[in]    path             path in sysfs to a host device
- *                                @see block_device::cntrl_path.
- * @param[in]    ibpi             an IBPI pattern (state) to visualize.
- *
- * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
- */
-typedef status_t (*send_message_t) (struct block_device *device, enum led_ibpi_pattern ibpi);
-
-/**
- * @brief Pointer to a flush buffer function.
- *
- * @param[in]    device           pointer to a block device
- *
- * @return 1 if successful, otherwise the function returns 0.
- */
-typedef int (*flush_message_t) (struct block_device *device);
-
-/**
  * @brief Describes a block device.
  *
  * This structure describes a block device. It does not describe virtual devices
@@ -62,15 +39,21 @@ struct block_device {
 
 /**
  * The pointer to a function which sends a message to driver in order to
- * control LEDs in an enclosure or DAS system - @see send_message_t for details.
- * This field cannot have NULL pointer assigned.
+ * control LEDs in an enclosure or DAS system.
+ * Params:
+ *	device - pointer to a block device.
+ *	ibpi - an IBPI pattern (state) to visualize.
+ * Return: STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-	send_message_t send_fn;
+	status_t (*send_message_fn)(struct block_device *device, enum led_ibpi_pattern ibpi);
 
 /**
- * The pointer to a function which flush buffers filled by send_fn.
+ * The pointer to a function which flush buffers filled by send_message_fn.
+ * Params:
+ *	device - pointer to a block device.
+ * Return 1 if successful, otherwise the function returns 0.
  */
-	flush_message_t flush_fn;
+	int (*flush_message_fn)(struct block_device *device);
 
 /**
  * Canonical path to block device where enclosure management fields are located.

--- a/src/lib/block.h
+++ b/src/lib/block.h
@@ -26,10 +26,9 @@ struct block_device;
  *                                @see block_device::cntrl_path.
  * @param[in]    ibpi             an IBPI pattern (state) to visualize.
  *
- * @return 1 if successful, otherwise the function returns 0.
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-typedef int (*send_message_t) (struct block_device *device,
-			       enum led_ibpi_pattern ibpi);
+typedef status_t (*send_message_t) (struct block_device *device, enum led_ibpi_pattern ibpi);
 
 /**
  * @brief Pointer to a flush buffer function.

--- a/src/lib/dellssd.h
+++ b/src/lib/dellssd.h
@@ -6,6 +6,6 @@
 #include "block.h"
 #include "sysfs.h"
 
-int dellssd_write(struct block_device *device, enum led_ibpi_pattern ibpi);
+status_t dellssd_write(struct block_device *device, enum led_ibpi_pattern ibpi);
 char *dellssd_get_path(const char *cntrl_path);
 int get_dell_server_type(struct led_ctx *ctx);

--- a/src/lib/enclosure.c
+++ b/src/lib/enclosure.c
@@ -258,12 +258,14 @@ status_t enclosure_set_state(struct slot_property *sp, enum led_ibpi_pattern sta
 {
 	struct enclosure_device *enclosure_device = sp->slot_spec.ses.encl;
 	int index = sp->slot_spec.ses.slot_num;
+	int rc;
 
-	int rc = scsi_ses_write_enclosure(enclosure_device, index, state);
-	if (rc != 0) {
+	status_t status = scsi_ses_write_enclosure(enclosure_device, index, state);
+
+	if (status != STATUS_SUCCESS) {
 		lib_log(enclosure_device->ctx, LED_LOG_LEVEL_ERROR,
-			"SCSI: ses write failed %d\n", rc);
-		return STATUS_FILE_WRITE_ERROR;
+			"SCSI: ses write failed %d\n", status);
+		return status;
 	}
 
 	rc = scsi_ses_flush_enclosure(enclosure_device);

--- a/src/lib/libled.c
+++ b/src/lib/libled.c
@@ -119,7 +119,7 @@ led_status_t led_set(struct led_ctx *ctx, const char *path, enum led_ibpi_patter
 
 	list_for_each(sysfs_get_block_devices(ctx), device) {
 		if (strcmp(device->sysfs_path, path) == 0) {
-			device->send_fn(device, ibpi);
+			device->send_message_fn(device, ibpi);
 			return LED_STATUS_SUCCESS;
 		}
 	}
@@ -131,7 +131,7 @@ void led_flush(struct led_ctx *ctx)
 	struct block_device *device;
 
 	list_for_each(sysfs_get_block_devices(ctx), device) {
-		device->flush_fn(device);
+		device->flush_message_fn(device);
 	}
 }
 

--- a/src/lib/libled_internal.c
+++ b/src/lib/libled_internal.c
@@ -52,8 +52,8 @@ void off_all(struct led_ctx *ctx)
 	struct block_device *device;
 
 	list_for_each(sysfs_get_block_devices(ctx), device) {
-		device->send_fn(device, LED_IBPI_PATTERN_LOCATE_OFF);
-		device->flush_fn(device);
+		device->send_message_fn(device, LED_IBPI_PATTERN_LOCATE_OFF);
+		device->flush_message_fn(device);
 	}
 }
 

--- a/src/lib/npem.c
+++ b/src/lib/npem.c
@@ -270,10 +270,7 @@ status_t npem_set_slot(struct led_ctx *ctx, const char *sysfs_path, enum led_ibp
 	return STATUS_SUCCESS;
 }
 
-/*
- * FIXME: Error is not checked, no need to translate to errno based codes.
- */
-int npem_write(struct block_device *device, enum led_ibpi_pattern ibpi)
+status_t npem_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 {
 	if (ibpi == device->ibpi_prev)
 		return STATUS_SUCCESS;

--- a/src/lib/npem.h
+++ b/src/lib/npem.h
@@ -10,7 +10,7 @@
 #include "sysfs.h"
 
 int is_npem_capable(const char *path, struct led_ctx *ctx);
-int npem_write(struct block_device *device, enum led_ibpi_pattern ibpi);
+status_t npem_write(struct block_device *device, enum led_ibpi_pattern ibpi);
 char *npem_get_path(const char *cntrl_path);
 
 /**

--- a/src/lib/scsi.c
+++ b/src/lib/scsi.c
@@ -99,31 +99,30 @@ int scsi_get_enclosure(struct led_ctx *ctx, struct block_device *device)
 
 /**
  */
-int scsi_ses_write(struct block_device *device, enum led_ibpi_pattern ibpi)
+status_t scsi_ses_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 {
 	if (!device || !device->sysfs_path || !device->enclosure ||
 	    device->encl_index == -1)
-		__set_errno_and_return(EINVAL);
+		return STATUS_DATA_ERROR;
 
 	/* write only if state has changed */
 	if (ibpi == device->ibpi_prev)
-		return 1;
+		return STATUS_SUCCESS;
 
 	if ((ibpi < LED_IBPI_PATTERN_NORMAL) || (ibpi > LED_SES_REQ_FAULT))
-		__set_errno_and_return(ERANGE);
+		return LED_STATUS_INVALID_STATE;
 
 	return ses_write_msg(ibpi, &device->enclosure->ses_pages, device->encl_index);
 }
 
-int scsi_ses_write_enclosure(struct enclosure_device *enclosure, int idx,
-			     enum led_ibpi_pattern ibpi)
+status_t scsi_ses_write_enclosure(struct enclosure_device *enclosure, int idx,
+				  enum led_ibpi_pattern ibpi)
 {
-	if (!enclosure || idx == -1) {
-		__set_errno_and_return(EINVAL);
-	}
+	if (!enclosure || idx == -1)
+		return STATUS_DATA_ERROR;
 
 	if ((ibpi < LED_IBPI_PATTERN_NORMAL) || (ibpi > LED_SES_REQ_FAULT))
-		__set_errno_and_return(ERANGE);
+		return STATUS_INVALID_STATE;
 
 	return ses_write_msg(ibpi, &enclosure->ses_pages, idx);
 }

--- a/src/lib/scsi.h
+++ b/src/lib/scsi.h
@@ -27,9 +27,9 @@ char *scsi_get_host_path(const char *path, const char *cntrl_path);
  * @param[in]      device         Sysfs path of a drive in enclosure.
  * @param[in]      ibpi           IBPI pattern to visualize.
  *
- * @return 0 on success, otherwise error.
+ * @return STATUS_SUCCESS on success, otherwise a valid status_t status code.
  */
-int scsi_ses_write(struct block_device *device, enum led_ibpi_pattern ibpi);
+status_t scsi_ses_write(struct block_device *device, enum led_ibpi_pattern ibpi);
 
 /**
  * @brief Sends message to SES processor of an enclosure.
@@ -74,10 +74,10 @@ struct block_device *locate_block_by_sas_addr(struct led_ctx *ctx, uint64_t sas_
  * @param[in]      idx            slot in enclosure
  * @param[in]      ibpi           IBPI pattern to visualize.
  *
- * @return 0 on success, otherwise error.
+ * @return STATUS_SUCCESS on success, otherwise a valid status_t status code.
  */
-int scsi_ses_write_enclosure(struct enclosure_device *enclosure, int idx,
-			     enum led_ibpi_pattern ibpi);
+status_t scsi_ses_write_enclosure(struct enclosure_device *enclosure, int idx,
+				  enum led_ibpi_pattern ibpi);
 
 /**
  * @brief Sends message to SES processor of an enclosure.

--- a/src/lib/ses.c
+++ b/src/lib/ses.c
@@ -396,7 +396,7 @@ static int ses_set_message(enum led_ibpi_pattern ibpi, struct ses_slot_ctrl_elem
 	return 0;
 }
 
-int ses_write_msg(enum led_ibpi_pattern ibpi, struct ses_pages *sp, int idx)
+status_t ses_write_msg(enum led_ibpi_pattern ibpi, struct ses_pages *sp, int idx)
 {
 	/* Move do descriptors */
 	struct ses_slot_ctrl_elem *descriptors = (void *)(sp->page2.buf + 8);
@@ -430,7 +430,7 @@ int ses_write_msg(enum led_ibpi_pattern ibpi, struct ses_pages *sp, int idx)
 	if (desc_element) {
 		int ret = ses_set_message(ibpi, desc_element);
 		if (ret)
-			return ret;
+			return STATUS_INVALID_STATE;
 
 		sp->changes++;
 
@@ -443,10 +443,10 @@ int ses_write_msg(enum led_ibpi_pattern ibpi, struct ses_pages *sp, int idx)
 		if (local_element_type != SES_ARRAY_DEVICE_SLOT)
 			desc_element->array_slot_control = 0;
 
-		return 0;
+		return STATUS_SUCCESS;
 	}
 
-	return 1;
+	return STATUS_FILE_WRITE_ERROR;
 }
 
 int ses_send_diag(int fd, struct ses_pages *sp)

--- a/src/lib/ses.h
+++ b/src/lib/ses.h
@@ -7,6 +7,7 @@
 #include <asm/types.h>
 
 #include "led/libled.h"
+#include <status.h>
 
 /* Size of buffer for SES-2 Messages. */
 #define SES_ALLOC_BUFF 4096
@@ -57,7 +58,7 @@ struct ses_slot {
 };
 
 int ses_load_pages(int fd, struct ses_pages *sp, struct led_ctx *ctx);
-int ses_write_msg(enum led_ibpi_pattern ibpi, struct ses_pages *sp, int idx);
+status_t ses_write_msg(enum led_ibpi_pattern ibpi, struct ses_pages *sp, int idx);
 int ses_send_diag(int fd, struct ses_pages *sp);
 int ses_get_slots(struct ses_pages *sp, struct ses_slot **out_slots, int *out_slots_count);
 

--- a/src/lib/smp.h
+++ b/src/lib/smp.h
@@ -54,10 +54,9 @@ struct gpio_tx_register_byte {
  * @param[in]      device         Path to a smp device in sysfs.
  * @param[in]      ibpi           IBPI pattern to visualize.
  *
- * @return 1 if successful or -1 in case of error
- *         and errno is set to appropriate error code.
+ * @return STATUS_SUCCESS if successful, otherwise a valid status_t status code.
  */
-int scsi_smp_fill_buffer(struct block_device *device, enum led_ibpi_pattern ibpi);
+status_t scsi_smp_fill_buffer(struct block_device *device, enum led_ibpi_pattern ibpi);
 
 /**
  * @brief Sends message to SMP device.

--- a/src/lib/vmdssd.c
+++ b/src/lib/vmdssd.c
@@ -165,7 +165,7 @@ status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum led_ibpi_pattern
 	return STATUS_SUCCESS;
 }
 
-int vmdssd_write(struct block_device *device, enum led_ibpi_pattern ibpi)
+status_t vmdssd_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 {
 	struct pci_slot *slot;
 	char *short_name = strrchr(device->sysfs_path, '/');
@@ -176,16 +176,16 @@ int vmdssd_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 		short_name = device->sysfs_path;
 
 	if (ibpi == device->ibpi_prev)
-		return 0;
+		return STATUS_SUCCESS;
 
 	if ((ibpi < LED_IBPI_PATTERN_NORMAL) || (ibpi > LED_IBPI_PATTERN_LOCATE_OFF))
-		__set_errno_and_return(ERANGE);
+		return STATUS_INVALID_STATE;
 
 	slot = vmdssd_find_pci_slot(device->cntrl->ctx, device->sysfs_path);
 	if (!slot) {
 		lib_log(device->cntrl->ctx, LED_LOG_LEVEL_DEBUG,
 			"PCI hotplug slot not found for %s\n", short_name);
-		__set_errno_and_return(ENODEV);
+		return STATUS_NULL_POINTER;
 	}
 
 	return vmdssd_write_attention_buf(slot, ibpi);

--- a/src/lib/vmdssd.h
+++ b/src/lib/vmdssd.h
@@ -16,7 +16,7 @@
 #define ATTENTION_REBUILD    0x5  /* (0101) Attention On, Power On */
 #define ATTENTION_FAILURE    0xD  /* (1101) Attention On, Power Off */
 
-int vmdssd_write(struct block_device *device, enum led_ibpi_pattern ibpi);
+status_t vmdssd_write(struct block_device *device, enum led_ibpi_pattern ibpi);
 char *vmdssd_get_path(const char *cntrl_path);
 char *vmdssd_get_domain(const char *path);
 struct pci_slot *vmdssd_find_pci_slot(struct led_ctx *ctx, char *device_path);


### PR DESCRIPTION
The change is implemented due to the method of pattern determination.

When a volume RAID is in following states:
- rebuild is in progress,
- change number of drives in RAID 0,

by-default active members will have LED_IBPI_PATTERN_DEGRADED
pattern determined, which is not supported by most of controllers.
This case will cause the LED status not to be updated. It can be
overwritten during determination if we enable flags BLINK_ON_MIGR or
REBUILD_BLINK_ON_ALL.

In case ledmon was restarted with conf flags (BLINK_ON_MIGR,
REBUILD_BLINK_ON_ALL) changed from enabled to disabled, drive may contain
incorrect LED status set by the previous lunch of ledmon.

A similar situation is with LED_IBPI_PATTERN_HOTSPARE pattern, which is
not supported by part of controllers.

This change in case the controller returns STATUS_INVALID_STATE for
LED_IBPI_PATTERN_DEGRADED, adds an attempt to set the LED status to Normal
pattern, to make LED status neutral.

Change required unification of the returned status by functions
responsible for setting the LED status in supported controllers, to make
ledmon recognize in general three statuses success, fail and
"status not supported".
