### PR TITLE
Add gcc 14 and fix GH actions

### DIFF
--- a/.github/.checkpatch.conf
+++ b/.github/.checkpatch.conf
@@ -12,3 +12,4 @@
 --ignore COMPLEX_MACRO
 --ignore LONG_LINE_STRING
 --ignore EMBEDDED_FILENAME
+--exclude .github

--- a/.github/install_debs_compilation.sh
+++ b/.github/install_debs_compilation.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/bash
 
 # Install gcc
-if [ -z "$1" ]; then
-       sudo apt-get update && sudo apt-get install gcc-$1 g++-$1
+if [ ! -z "$1" ]; then
+       sudo apt-get -y update && sudo apt-get -y install gcc-$1 g++-$1
 fi
 # Install dependencies
-sudo apt-get install pkg-config automake autoconf autoconf-archive make libsgutils2-dev \
+sudo apt-get -y install pkg-config automake autoconf autoconf-archive make libsgutils2-dev \
         libudev-dev libpci-dev check devscripts

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,7 +6,7 @@ permissions: read-all
 jobs:
   commits_review:
     name: Commits review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -14,6 +14,8 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+    - name: 'Move prepared .checkpatch.conf file to main directory'
+      run: mv .github/.checkpatch.conf .
     - name: Run checkpatch review
       uses: webispy/checkpatch-action@v9
     - name: Set up Python 3.11

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -8,12 +8,10 @@ jobs:
     name: Commits review
     runs-on: ubuntu-latest
     steps:
-    - name: 'Calculate PR commits + 1'
-      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> $GITHUB_ENV
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+        fetch-depth: 0
     - name: 'Move prepared .checkpatch.conf file to main directory'
       run: mv .github/.checkpatch.conf .
     - name: Run checkpatch review

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,21 +5,27 @@ env:
 permissions: read-all
 jobs:
   make:
+    # when gcc is not found, it may be needed to update runner version
+    runs-on: ubuntu-24.04
     name: Compilation test with gcc
     strategy:
       matrix:
-        gcc-version: [7, 8, 9, 10, 11, 12, 13]
-    runs-on: ubuntu-latest
+        # gcc-versions are used to test up to 5 years old
+        gcc-version: [9, 10, 11, 12, 13, 14]
     steps:
       - uses: actions/checkout@v4
       - name: 'Add ubuntu repositories'
         run: .github/configure_apt.sh
       - name: 'Install building dependencies'
         run: .github/install_debs_compilation.sh ${{ matrix.gcc-version }}
+      - name: 'Check if gcc was installed correctly'
+        run: gcc-${{ matrix.gcc-version }} --version
+      - name: 'Check if g++ was installed correctly'
+        run: g++-${{ matrix.gcc-version }} --version
       - name: 'Generate compiling configurations with library disabled'
         run: . ./autogen.sh && ./configure CFLAGS=${{ env.cflags }}
       - name: 'Make'
-        run: CC=gcc-${{ matrix.gcc-version }} CXX=g++-${{ matrix.gcc-version }} && V=1 make -j$(nproc)
+        run: V=1 make -j$(nproc) CC=gcc-${{ matrix.gcc-version }} CXX=g++-${{ matrix.gcc-version }} 
       - name: 'Hardening check: ledmon'
         run: hardening-check src/ledmon/ledmon
       - name: 'Hardening check: ledctl'
@@ -31,7 +37,7 @@ jobs:
       - name: 'Generate compiling configurations with library enabled'
         run: . .github/build_configure.sh ${{ env.cflags }}
       - name: 'Make'
-        run: CC=gcc-${{ matrix.gcc-version }} CXX=g++-${{ matrix.gcc-version }} && V=1 make -j$(nproc)
+        run: V=1 make -j$(nproc) CC=gcc-${{ matrix.gcc-version }} CXX=g++-${{ matrix.gcc-version }}
       - name: 'Hardening check: ledmon'
         run: hardening-check src/ledmon/ledmon
       - name: 'Hardening check: ledctl'
@@ -40,7 +46,7 @@ jobs:
         run: tests/check_symbol_visibility.sh
   clangcompile:
     name: Compilation test with clang
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: 'Add ubuntu repositories'
@@ -57,9 +63,9 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        gcc-version: [12]
-        python-version: ["3.7"]
-    runs-on: ubuntu-latest
+        gcc-version: [13]
+        python-version: ["3.9"]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: 'Add ubuntu repositories'
@@ -69,7 +75,7 @@ jobs:
       - name: 'Generate compiling configurations'
         run: .github/build_configure.sh ${{ env.cflags }}
       - name: 'Make'
-        run: CC=gcc-${{ matrix.gcc-version }} CXX=g++-${{ matrix.gcc-version }} && V=1 make -j$(nproc)
+        run: V=1 make -j$(nproc) CC=gcc-${{ matrix.gcc-version }} CXX=g++-${{ matrix.gcc-version }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
PR contains fixed to files which are using by GitHub actions.

Change runner to Ubuntu 24.04 which supports gcc versions up to 14.
Previously ubuntu-latest was used (22.04) which didn't support gcc 13
and 14. Add verification if correct gcc was installed during test.
Setting fetch-depth to 0 to fetch all of the history of all branches and tags.
When .checkpatch.conf is placed in main repo directory, it will be used
by system checkpatch when user will run scan on his patch. To avoid it,
and use this conf file only to GH action, it was moved outside main
repository. While GH action is running, conf file is being moved to main
directory back, which makes possible to use it while checkpatch action.