### PR TITLE
docs: minor updates for accessibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,13 @@
 Verification of License and Copyrights is automated on Github by
 [Licensing test](https://github.com/intel/ledmon/blob/main/tests/licensing.py).
 
-The rules for Licenses and Copyrights:
+The rules for Licenses and Copyrights are as follows:
 - Preferred comment mark should be used for file type. Please prefer to test or other files for
   examples. For `.c` and `.h` files, it is `//`.
 - [SPDX Licenses](https://spdx.org/licenses/) must be used:
-  - It must be on first  or in third line (only if interpreter is defined);
+  - It must be on the first or the third line (only if interpreter is defined);
   - Verification script contains set of allowed licenses for directories to avoid legal issues.
-    If you need to honour other license type, test must be extended.
+    If you need to honor other license types, tests must be extended.
 - Immediately after SPDX header Copyright lines may come. There are multiple Copyrights lines
   allowed.
 - Only Intel copyright must follow strict style check.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See http://www.gnu.org/ for details.
 
 -------------------------
 
-Following packages are required to compile:
+The following packages are required for compilation:
 
 |RHEL|SLES|Debian/Ubuntu|
 |:---:|:---:|:---:|
@@ -34,7 +34,7 @@ Following packages are required to compile:
 
 -------------------------
 
-Run `autogen.sh` to generate compiling configurations:
+Run `autogen.sh` to generate compilation configurations:
    `./autogen.sh`
    `./configure`
 
@@ -57,22 +57,22 @@ Run `./configure` with:
 
 Run `make` command to compile the package.
 
-## 4. (Un)installing the package
+## 4. Installing or uninstalling the package
 
 -------------------------
 
-Run following commands to install package:
+Run the following command to install the package:
    `make install`
 
-Run following commands to uninstall package:
+Run the following command to uninstall the package:
    `make uninstall`
 
 ## 5. Release notes
 
 -------------------------
 
-a. Enclosure LED Utilities is meant as a part of RHEL, SLES and Debian/Ubuntu linux
+a. Enclosure LED Utilities are included as a part of RHEL, SLES and Debian/Ubuntu linux
    distributions.
 
-b. For backplane enclosures attached to ISCI controller support is limited to
+b. For backplane enclosures attached to an iSCI controller support is limited to
    Intel(R) Intelligent Backplane.

--- a/doc/ledctl.pod
+++ b/doc/ledctl.pod
@@ -13,7 +13,7 @@ B<ledctl> [I<MODE>] [I<OPTIONS>] ...
 
 =head1 DESCRIPTION
 
-The ledctl is an user-space application designed to control LEDs associated with each
+Ledctl is a user-space application designed to control LEDs associated with each
 slot in an enclosure or a drive bay. Root privileges are required for its operation.
 
 
@@ -39,15 +39,15 @@ B<VMD and NPEM> for PCIe.
 
 B<SAF-TE> protocol is not supported.
 
-For SAS/SATA storages supporting controllers may transmit LED management
+For SAS/SATA storage, supporting controllers may transmit LED management
 information to the backplane controllers via the SGPIO interface. The SGPIO
 bus carries bit patterns, which translate into LED blink patterns in
 accordance with the International Blinking Pattern Interpretation (IBPI)
 of SFF-8489 specification for SGPIO.
-Please note some enclosures do not stick close to the SFF-8489
-specification. It might happen that the enclosure processor will accept
-the IBPI pattern but it will blink LEDs not according to SFF-8489
-specification or it has a limited number of patterns supported.
+Please note some enclosures do not stick closely to the SFF-8489
+specification. It might occur that the enclosure processor will accept
+the IBPI pattern but will not blink LEDs according to SFF-8489
+specification.  Or, it may have a limited number of patterns supported.
 
 The ledctl application has been verified to work with Intel(R) storage
 controllers (i.e. Intel(R) AHCI controller and Intel(R) SAS controller).
@@ -56,8 +56,8 @@ The application might work with storage controllers of other vendors
 vendors have not been tested.
 
 The ledmon application has the highest priority when accessing LEDs.
-It means that some patterns set by ledctl may have no effect if ledmon is running
-(except Locate pattern).
+Meaning that some patterns set by ledctl may have no effect if ledmon is running
+(exception: Locate pattern).
 
 The ledctl application is a part of Intel(R) Enclosure LED Utilities.
 
@@ -233,8 +233,8 @@ SES-2 PRDFAIL
 
 =head2 Patterns Translation
 
-When non SES-2 pattern is send to device in enclosure automatic
-translation is being done.
+When a non SES-2 pattern is sent to device an enclosure automatic
+translation is done.
 
 =over 8
 
@@ -279,7 +279,7 @@ I<failure> or I<disk_failed> is translated to I<ses_fault>
 =head1 MODES AND MODE SPECIFIC OPTIONS
 
 This chapter outlines the modes and options applicable to specific modes. If no mode is
-specified, it defaults to IBPI mode.
+specified, the default is IBPI mode.
 
 =head2 B<-I> or B<--ibpi>
 
@@ -333,7 +333,7 @@ or B<--slot> and B<--state>.
 
 =item B<-p I<state>> or B<--state=I<state>>
 
-It is mandatory for B<--set-slot>. It provides state to be set for the slot. Refer to
+It is mandatory for B<--set-slot>. It provides the state to be set for the slot. Refer to
 "Pattern names" for supported states list.
 
 =back
@@ -411,27 +411,27 @@ C<ledctl --ibpi locate=/dev/sda>
 C<ledctl --ibpi --listed-only locate_off=/dev/sda>
 
 =head2 The following example illustrates how to set I<off> on the given devices. It uses second
-format of device list.
+format of the device list.
 
 C<ledctl --ibpi --listed-only off={ /dev/sda /dev/sdb }>
 
 =head2 The following example illustrates how to set I<locate> and I<rebuild> on different devices
-at the same time. It uses the second format of device list.
+at the same time. It uses the second format of the device list.
 
 C<ledctl --ibpi --listed-only locate={ /dev/sdb } rebuild={ /sys/block/sdc }>
 
 =head2 The following example illustrates how to I<locate> on three block devices. It uses the first
-format of device list.
+format of the device list.
 
 C<ledctl --ibpi --listed-only locate=/dev/sda,/dev/sdb,/dev/sdc>
 
 =head2 The following example illustrates how to set I<locate> and I<rebuild> on different devices
-at the same time. It uses the first format of device list.
+at the same time. It uses the first format of the device list.
 
 C<ledctl --ibpi --listed-only locate=/dev/sdb rebuild=/sys/block/sdc>
 
 =head2 The following example illustrates how to set I<locate> and I<rebuild> on different devices
-at the same time. It uses the both formats of device list.
+at the same time. It uses the both formats of the device list.
 
 C<ledctl --ibpi --listed-only locate={ /dev/sdb } rebuild=/sys/block/sdc>
 

--- a/doc/ledmon.conf.pod
+++ b/doc/ledmon.conf.pod
@@ -10,19 +10,19 @@ ledmon.conf - Configuration file for Intel(R) Enclosure LED Utilities.
 =head1 DESCRIPTION
 
 The ledmon configuration file allows you to use advanced settings and functions
-of Intel(R) Enclosure LED Utilities. The global location of the configuration
+of the Intel(R) Enclosure LED Utilities. The global location of the configuration
 file is F</etc/ledmon.conf>. Instead of a global configuration file, you can
 specify a local config file using the I<-c> option when running ledmon.
 
 =head2 SYNTAX
 
-One line should keep exactly one option and value in the configuration file in
-format: OPTION=VALUE. Any word that begins with a hash sign (B<#>) starts a
+One line should have exactly one option and value in the configuration file in
+format: OPTION=VALUE. Any word that begins with a hash sign (B<#>) is considered a
 comment and that word together with the remainder of the line is ignored. Empty
 lines are allowed. Either single quotes (B<'>) or double quotes (B<">) should
 not be used.
 
-Values are considered as truth: enabled, true, yes, 1.
+Values are considered as true: enabled, true, yes, 1.
 
 Values are considered as false: disabled, false, no, 0.
 
@@ -30,7 +30,7 @@ See also the examples section.
 
 =head2 List of configurable options:
 
-B<EXCLUDELIST> - Ledmon will exclude scanning controllers listed on excludelist.
+B<EXCLUDELIST> - Ledmon will exclude scanning controllers listed on the excludelist.
 When allowlist is also set in config file, the excludelist will be ignored.
 The controllers should be separated by comma (B<,>) character. Only exact paths
 to the controller (e.g. /sys/devices/pci0000:c9/0000:c9:00.5) will be respected.
@@ -45,7 +45,7 @@ process. If value is set to false, processes like init or verifications will not
 be reported by LEDs. The default value is true.
 
 B<BLINK_ON_MIGR> - RAID can be migrated between some levels or strip sizes and
-the flag is related with this processes. Also RAID Grow operation will be
+the flag is related with these processes. Also, the RAID Grow operation will be
 reported along with this flag. If value is set to true - status LEDs of all
 member drives will blink with proper pattern if RAID volume is under reshape.
 If value is set to false, listed actions will not be reported by LEDs. The
@@ -72,8 +72,8 @@ with appropriate LED pattern. If value is set to true all drives from RAID
 that is during rebuild will blink during this operation.
 
 B<ALLOWLIST> - Ledmon will limit changing LED state to controllers listed on
-allowlist. If any allowlist is set, only devices from list will be scanned by
-ledmon. The controllers should be separated by comma (B<,>) character. Only
+allowlist. If any allowlist is set, only devices from the list will be scanned by
+ledmon. The controllers should be separated by a comma (B<,>) character. Only
 exact paths to the controller (e.g. /sys/devices/pci0000:c9/0000:c9:00.5)
 will be respected.
 The B<XBD Extended Regular Expressions> are supported.  The deprecated name of

--- a/doc/ledmon.pod
+++ b/doc/ledmon.pod
@@ -13,16 +13,16 @@ B<ledmon> [I<OPTIONS>]
 
 =head1 DESCRIPTION
 
-The ledmon application is a daemon process used to monitor a state of
-software RAID devices (md only) or a state of block devices. The state
-is visualizing on LEDs associated to each slot in an enclosure or a
-drive bay. There are two types of system: 2-LEDs system (Activity LED,
-Status LED) and 3-LEDs system (Activity LED, Locate LED, Fail
+The ledmon application is a daemon process used to monitor the state(s) of
+software RAID devices (md only) or the state(s) of block devices. The state
+is visualized on LEDs associated with each slot in an enclosure or a
+drive bay. There are two types of systems: 2-LEDs systems (Activity LED,
+Status LED) and 3-LEDs systems (Activity LED, Locate LED, Fail
 LED). This application has the highest priority when accessing the
 LEDs.
 
 The ledmon application supports LED management of the SAS/SATA and PCIe
-storages.
+storage.
 
 =head4 Supported protocols/methods for LED management are:
 
@@ -44,22 +44,22 @@ B<VMD and NPEM> for PCIe.
 
 B<SAF-TE> protocol is not supported.
 
-For SAS/SATA storages supporting controllers may transmit LED management
+For SAS/SATA supported storage, controllers may transmit LED management
 information to the backplane controllers via the SGPIO interface. The SGPIO
 bus carries bit patterns, which translate into LED blink patterns in
 accordance with the International Blinking Pattern Interpretation (IBPI)
 of SFF-8489 specification for SGPIO.
-Please note some enclosures do not stick close to the SFF-8489
-specification. It might happen that the enclosure processor will accept
+Please note some enclosures do not stick closely to the SFF-8489
+specification. It might occur that the enclosure processor will accept
 the IBPI pattern but it will blink LEDs not according to SFF-8489
-specification or it has a limited number of patterns supported.
+specification.  Or, it may have a limited number of patterns supported.
 
 For more information about communication methods please consult the
 appropriate Specifications.
 
 There's no method provided to specify which RAID volume should be monitored
 and which not. The ledmon application monitors all RAID devices and visualizes
-their state.
+their state(s).
 
 The ledmon application has been verified to work with Intel(R) storage
 controllers (i.e. Intel(R) AHCI controller and Intel(R) SAS controller).


### PR DESCRIPTION
Several minor updates based on English grammar to help those with low vision more easily read the docs.  For those with low vision, like me, a missing word or misplaced article (a, the) can add to the confusion while trying to read a sentence when the words tend to 'jump around' a bit.

This is part of ledmon taking an ''accessibility pledge' to better support diversity and inclusion.