### PR TITLE
Use char array for path variables

### DIFF
--- a/src/ledmon/ledmon.c
+++ b/src/ledmon/ledmon.c
@@ -681,12 +681,6 @@ static void _add_block(struct block_device *block)
 		if (strcmp(temp->sysfs_path, block->sysfs_path)) {
 			log_info("NAME CHANGED %s to %s",
 				 temp->sysfs_path, block->sysfs_path);
-			free(temp->sysfs_path);
-			temp->sysfs_path = strdup(block->sysfs_path);
-			if (!temp->sysfs_path) {
-				log_error("Memory allocation error!");
-				EXIT(1);
-			}
 		}
 	} else {
 		/* Device not found, it's a new one! */

--- a/src/ledmon/udev.c
+++ b/src/ledmon/udev.c
@@ -116,7 +116,7 @@ static enum udev_action _get_udev_action(const char *action)
 
 static void _clear_raid_dev_info(struct block_device *block, char *raid_dev)
 {
-	if (block->raid_dev && block->raid_dev->sysfs_path) {
+	if (block->raid_dev) {
 		char *tmp = strrchr(block->raid_dev->sysfs_path, '/');
 
 		if (tmp == NULL) {

--- a/src/lib/ahci.c
+++ b/src/lib/ahci.c
@@ -51,7 +51,7 @@ static const struct ibpi2value ibpi2sgpio[] = {
 status_t ahci_sgpio_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 {
 	char temp[WRITE_BUFFER_SIZE];
-	char path[PATH_MAX];
+	char path[PATH_MAX + strlen("/em_message")];
 	char *sysfs_path = device->cntrl_path;
 	const struct timespec waittime = {
 		.tv_sec = 0,

--- a/src/lib/block.c
+++ b/src/lib/block.c
@@ -308,10 +308,8 @@ struct block_device *block_device_init(const struct list *cntrl_list, const char
 
 	hosts = cntrl->hosts;
 	device->cntrl = cntrl;
-	device->sysfs_path = strdup(link);
-	if (!device->sysfs_path)
-		goto error;
-	device->cntrl_path = host;
+	str_cpy(device->sysfs_path, link, PATH_MAX);
+	str_cpy(device->cntrl_path, host, PATH_MAX);
 	block_set_devnode(device);
 	device->ibpi = LED_IBPI_PATTERN_UNKNOWN;
 	device->ibpi_prev = LED_IBPI_PATTERN_NONE;
@@ -345,10 +343,8 @@ struct block_device *block_device_init(const struct list *cntrl_list, const char
 	return device;
 error:
 	free(host);
-	if (device) {
-		free(device->sysfs_path);
+	if (device)
 		free(device);
-	}
 	return NULL;
 }
 
@@ -358,12 +354,6 @@ error:
 void block_device_fini(struct block_device *device)
 {
 	if (device) {
-		if (device->sysfs_path)
-			free(device->sysfs_path);
-
-		if (device->cntrl_path)
-			free(device->cntrl_path);
-
 		if (device->raid_dev)
 			raid_device_fini(device->raid_dev);
 
@@ -381,16 +371,8 @@ struct block_device *block_device_duplicate(struct block_device *block)
 	if (block) {
 		result = calloc(1, sizeof(*result));
 		if (result) {
-			result->sysfs_path = strdup(block->sysfs_path);
-			result->cntrl_path = strdup(block->cntrl_path);
-
-			if (!result->sysfs_path || !result->cntrl_path) {
-				free(result->sysfs_path);
-				free(result->cntrl_path);
-				free(result);
-				return NULL;
-			}
-
+			str_cpy(result->sysfs_path, block->sysfs_path, PATH_MAX);
+			str_cpy(result->cntrl_path, block->cntrl_path, PATH_MAX);
 			if (block->ibpi != LED_IBPI_PATTERN_UNKNOWN)
 				result->ibpi = block->ibpi;
 			else

--- a/src/lib/block.h
+++ b/src/lib/block.h
@@ -29,7 +29,7 @@ struct block_device {
  * may not exist in sysfs if connection to physical drive is lost. This filed
  * cannot have NULL pointer assigned.
  */
-	char *sysfs_path;
+	char sysfs_path[PATH_MAX];
 
 /**
  * Main devnode we can reach this device. It may not match /sys/dev/block/MAJ:MIN
@@ -62,7 +62,7 @@ struct block_device {
  * this path points to SES entry associated with the slot in an enclosure.
  * This field cannot have NULL pointer assign.
  */
-	char *cntrl_path;
+	char cntrl_path[PATH_MAX];
 
 /**
  * The current state of block device. This is an IBPI pattern and it is used

--- a/src/lib/pci_slot.c
+++ b/src/lib/pci_slot.c
@@ -29,10 +29,7 @@ struct pci_slot *pci_slot_init(const char *path, struct led_ctx *ctx)
 	result = calloc(1, sizeof(struct pci_slot));
 	if (result == NULL)
 		return NULL;
-	result->sysfs_path = strdup(path);
-	if (!result->sysfs_path) {
-		goto error;
-	}
+	strncpy(result->sysfs_path, path, PATH_MAX - 1);
 	result->address = get_text(path, "address");
 	if (!result->address)
 		goto error;
@@ -42,7 +39,6 @@ struct pci_slot *pci_slot_init(const char *path, struct led_ctx *ctx)
 	return result;
 error:
 	free(result->address);
-	free(result->sysfs_path);
 	free(result);
 	return NULL;
 }
@@ -54,7 +50,6 @@ error:
 void pci_slot_fini(struct pci_slot *slot)
 {
 	if (slot) {
-		free(slot->sysfs_path);
 		free(slot->address);
 		free(slot);
 	}

--- a/src/lib/pci_slot.h
+++ b/src/lib/pci_slot.h
@@ -15,12 +15,12 @@
  * This structure describes a PCI hotplug slot exposed by the hotplug driver.
  */
 struct pci_slot {
- /**
+/**
  * Path to PCI hotplug slot in sysfs tree.
  */
-	char *sysfs_path;
+	char sysfs_path[PATH_MAX];
 
- /**
+/**
  * PCI hotplug slot address.
  */
 	char *address;

--- a/src/lib/raid.c
+++ b/src/lib/raid.c
@@ -124,11 +124,7 @@ struct raid_device *raid_device_init(const char *path, unsigned int device_num,
 		if (!device)
 			return NULL;
 
-		device->sysfs_path = strdup(path);
-		if (!device->sysfs_path) {
-			free(device);
-			return NULL;
-		}
+		str_cpy(device->sysfs_path, path, PATH_MAX);
 		device->device_num = device_num;
 		device->sync_action = _get_sync_action(path);
 		device->array_state = state;
@@ -150,11 +146,8 @@ struct raid_device *raid_device_init(const char *path, unsigned int device_num,
  */
 void raid_device_fini(struct raid_device *device)
 {
-	if (device) {
-		if (device->sysfs_path)
-			free(device->sysfs_path);
+	if (device)
 		free(device);
-	}
 }
 
 /**
@@ -165,14 +158,8 @@ struct raid_device *raid_device_duplicate(struct raid_device *device)
 
 	if (device) {
 		new_device = malloc(sizeof(struct raid_device));
-		if (new_device) {
+		if (new_device)
 			*new_device = *device;
-			new_device->sysfs_path = strdup(device->sysfs_path);
-			if (!new_device->sysfs_path) {
-				free(new_device);
-				return NULL;
-			}
-		}
 	}
 	return new_device;
 }

--- a/src/lib/raid.h
+++ b/src/lib/raid.h
@@ -59,7 +59,7 @@ enum raid_action {
 struct raid_device {
 	enum device_type type;
 	int device_num;
-	char *sysfs_path;
+	char sysfs_path[PATH_MAX];
 	int raid_disks;
 	int degraded;
 	enum raid_state array_state;

--- a/src/lib/scsi.c
+++ b/src/lib/scsi.c
@@ -75,7 +75,7 @@ int scsi_get_enclosure(struct led_ctx *ctx, struct block_device *device)
 	struct enclosure_device *encl;
 	uint64_t addr;
 
-	if (!device || !device->sysfs_path)
+	if (!device)
 		return 0;
 
 	addr = get_drive_sas_addr(device->sysfs_path);
@@ -101,7 +101,7 @@ int scsi_get_enclosure(struct led_ctx *ctx, struct block_device *device)
  */
 status_t scsi_ses_write(struct block_device *device, enum led_ibpi_pattern ibpi)
 {
-	if (!device || !device->sysfs_path || !device->enclosure ||
+	if (!device || !device->enclosure ||
 	    device->encl_index == -1)
 		return STATUS_DATA_ERROR;
 

--- a/src/lib/sysfs.c
+++ b/src/lib/sysfs.c
@@ -188,7 +188,7 @@ static void _tail_cnt_add(struct led_ctx *ctx, const char *path, struct raid_dev
 static void _link_raid_device(struct led_ctx *ctx, struct raid_device *device,
 			      enum device_type type)
 {
-	char temp[PATH_MAX];
+	char temp[PATH_MAX + strlen("/md")];
 	struct list dir;
 
 	snprintf(temp, sizeof(temp), "%s/md", device->sysfs_path);

--- a/src/lib/vmdssd.c
+++ b/src/lib/vmdssd.c
@@ -35,7 +35,7 @@ struct ibpi2value ibpi_to_attention[] = {
 #define SYSFS_PCIEHP         "/sys/module/pciehp"
 #define SYSFS_VMD            "/sys/bus/pci/drivers/vmd"
 
-static char *get_slot_from_syspath(char *path)
+static char *get_slot_from_syspath(const char *path)
 {
 	char *cur, *ret = NULL;
 	char *temp_path = strdup(path);
@@ -97,7 +97,7 @@ bool vmdssd_check_slot_module(struct led_ctx *ctx, const char *slot_path)
 	return false;
 }
 
-struct pci_slot *vmdssd_find_pci_slot(struct led_ctx *ctx, char *device_path)
+struct pci_slot *vmdssd_find_pci_slot(struct led_ctx *ctx, const char *device_path)
 {
 	char *pci_addr;
 	struct pci_slot *slot = NULL;
@@ -132,7 +132,7 @@ enum led_ibpi_pattern vmdssd_get_attention(struct pci_slot *slot)
 
 status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum led_ibpi_pattern ibpi)
 {
-	char attention_path[PATH_MAX];
+	char attention_path[PATH_MAX + strlen("/attention")];
 	char buf[WRITE_BUFFER_SIZE];
 	const struct ibpi2value *ibpi2val;
 
@@ -152,7 +152,7 @@ status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum led_ibpi_pattern
 	val = (uint16_t)ibpi2val->value;
 
 	snprintf(buf, WRITE_BUFFER_SIZE, "%u", val);
-	snprintf(attention_path, PATH_MAX, "%s/attention", slot->sysfs_path);
+	snprintf(attention_path, sizeof(attention_path), "%s/attention", slot->sysfs_path);
 	if (buf_write(attention_path, buf) != (ssize_t) strnlen(buf, WRITE_BUFFER_SIZE)) {
 		lib_log(slot->ctx, LED_LOG_LEVEL_ERROR,
 			"%s write error: %d\n", slot->sysfs_path, errno);

--- a/src/lib/vmdssd.h
+++ b/src/lib/vmdssd.h
@@ -19,7 +19,7 @@
 status_t vmdssd_write(struct block_device *device, enum led_ibpi_pattern ibpi);
 char *vmdssd_get_path(const char *cntrl_path);
 char *vmdssd_get_domain(const char *path);
-struct pci_slot *vmdssd_find_pci_slot(struct led_ctx *ctx, char *device_path);
+struct pci_slot *vmdssd_find_pci_slot(struct led_ctx *ctx, const char *device_path);
 status_t vmdssd_write_attention_buf(struct pci_slot *slot, enum led_ibpi_pattern ibpi);
 enum led_ibpi_pattern vmdssd_get_attention(struct pci_slot *slot);
 bool vmdssd_check_slot_module(struct led_ctx *ctx, const char *slot_path);


### PR DESCRIPTION
Use the same way of declaration variable representing paths in system for all of the structs representing devices. Use char array to allocate memory in struct, not in function using this variable. Align implementation to this change.
Fixes #223.