### PR TITLE
utils: Fix string2ibpi function

### DIFF
--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -765,7 +765,7 @@ enum led_ibpi_pattern string2ibpi(const char *name)
 		if (!input_name)
 			continue;
 
-		if (strncmp(input_name, name, strlen(input_name)) == 0)
+		if (strcmp(input_name, name) == 0)
 			return ipbi_names[i].ibpi;
 	}
 


### PR DESCRIPTION
string2ibpi does not compare strings correctly, the function uses strncmp, which in case strings of different lengths, may return incorrect value if substrings of given max length are identical. In this function whole strings must be identical.

Fix is to change strncmp to strcmp.

Fixes intel/ledmon#259
Fixes: 94818457f615 ("Add struct for mapping ibpi statuses to strings. (#211)")
Signed-off-by: Blazej Kucman <blazej.kucman@intel.com>