### PR TITLE
Persistent slot ID support

### DIFF
--- a/src/lib/enclosure.c
+++ b/src/lib/enclosure.c
@@ -143,6 +143,8 @@ int enclosure_reload(struct enclosure_device * enclosure)
 	if (ret)
 		return ret;
 
+	enclosure->logical_identifier = ses_get_primary_logical_id(&enclosure->ses_pages);
+
 	/* If there is an associated block device with a slot, we need to update the block ibpi */
 	for (int i = 0; i < enclosure->slots_count; i++) {
 		struct block_device *bd = NULL;
@@ -269,6 +271,12 @@ struct slot_property *enclosure_slot_property_init(struct enclosure_device *encl
 	result->slot_spec.ses.encl = encl;
 	result->slot_spec.ses.slot_num = ses_idx;
 	snprintf(result->slot_id, PATH_MAX, "%s-%d", encl->dev_path, ses_idx);
+
+	/* If logical identifier is not supported, the logical identifier will be 0. */
+	if (encl->logical_identifier != 0)
+		snprintf(result->persistent_id, PATH_MAX, "%"PRIx64"-%d",
+			encl->logical_identifier, ses_idx);
+
 	result->c = &ses_slot_common;
 
 	/* If we have an associated block device, set its ibpi value */

--- a/src/lib/enclosure.h
+++ b/src/lib/enclosure.h
@@ -42,6 +42,11 @@ struct enclosure_device {
 	int slots_count;
 
 	struct led_ctx *ctx;
+
+  /**
+   * Enclosure logical identifier
+   */
+	uint64_t logical_identifier;
 };
 
 /**

--- a/src/lib/include/led/libled.h
+++ b/src/lib/include/led/libled.h
@@ -418,6 +418,17 @@ const LED_SYM_PUBLIC char *led_slot_device(struct led_slot_list_entry *se);
 const LED_SYM_PUBLIC char *led_slot_id(struct led_slot_list_entry *se);
 
 /**
+ * @brief Retrieve the persistent ID for the specified slot
+ *
+ * @param[in]	se	Slot entry of interest
+ * @return string pointer representing persistent ID, NULL if not supported
+ *
+ * Note: This pointer has a lifetime of ctx or until reset is called.
+ * Copy value if you need longer lifetime.
+ */
+const LED_SYM_PUBLIC char *led_slot_persistent_id(struct led_slot_list_entry *se);
+
+/**
  * @brief Retrieve the enumerated slot type for the specified slot
  *
  * @param[in]	se	 Slot entry of interest
@@ -470,6 +481,18 @@ LED_SYM_PUBLIC struct led_slot_list_entry *led_slot_find_by_device_name(struct l
  * @param[in]	se	Slot entry to free
  */
 LED_SYM_PUBLIC void led_slot_list_entry_free(struct led_slot_list_entry *se);
+
+/**
+ * @brief Check if the specified slot supports persistent IDs
+ *
+ * @param[in]	ctx	Library context
+ * @param[in]	cntrl	Controller type to check for persistent ID support
+ * @return true if controller should support persistent IDs, false otherwise
+ *
+ * Note: This function is used to check if the controller should support persistent IDs. For any
+ *       specific hardware implementation, this may or may not be true.
+ */
+bool LED_SYM_PUBLIC led_slot_persistent_id_support(struct led_ctx *ctx, enum led_cntrl_type cntrl);
 
 /**
  * @brief Set the ipbi pattern for a specified slot

--- a/src/lib/libled.c
+++ b/src/lib/libled.c
@@ -216,6 +216,11 @@ struct led_slot_list_entry *led_slot_find_by_device_name(struct led_ctx *ctx,
 	return init_slot(find_slot_by_device_name(ctx, device_name, cntrl));
 }
 
+bool led_slot_persistent_id_support(struct led_ctx *ctx, enum led_cntrl_type cntrl)
+{
+	return cntrl == LED_CNTRL_TYPE_SCSI;
+}
+
 led_status_t led_slot_set(struct led_ctx *ctx, struct led_slot_list_entry *se,
 				enum led_ibpi_pattern state)
 {
@@ -259,6 +264,14 @@ const char *led_slot_id(struct led_slot_list_entry *se)
 {
 	return se->slot->slot_id;
 }
+
+const char *led_slot_persistent_id(struct led_slot_list_entry *se)
+{
+	if (se->slot->persistent_id[0] == '\0')
+		return NULL;
+	return se->slot->persistent_id;
+}
+
 enum led_cntrl_type led_slot_cntrl(struct led_slot_list_entry *se)
 {
 	return se->slot->c->cntrl_type;

--- a/src/lib/ses.h
+++ b/src/lib/ses.h
@@ -66,5 +66,6 @@ int ses_load_pages(int fd, struct ses_pages *sp, struct led_ctx *ctx);
 status_t ses_write_msg(enum led_ibpi_pattern ibpi, struct ses_pages *sp, int idx);
 int ses_send_diag(int fd, struct ses_pages *sp);
 int ses_get_slots(struct ses_pages *sp, struct ses_slot **out_slots, int *out_slots_count);
+uint64_t ses_get_primary_logical_id(struct ses_pages *sp);
 
 #endif /* _SES_H_INCLUDED_ */

--- a/src/lib/slot.h
+++ b/src/lib/slot.h
@@ -71,6 +71,15 @@ struct slot_property {
 	 * Unique slot ID.
 	 */
 	char slot_id[PATH_MAX];
+
+	/**
+	 * @brief Persistent ID for the slot.
+	 *
+	 * This string that is the persistent ID for the slot.
+	 * It is used to identify the slot across reboots. Empty string if not supported.
+	 */
+	char persistent_id[PATH_MAX];
+
 };
 
 /**


### PR DESCRIPTION
Slot identifiers today are assigned at discovery time, so they can shift
across boots or hot-plug events.  This makes it hard for callers to track
a drive once it becomes unresponsive or the kernel drops it.

Two public functions added.

1. `bool led_slot_persistent_id_support(struct led_ctx *ctx, enum led_cntrl_type cntrl)`

   Which simply returns true if persistent ID support exists for the
   controller type

2. `char *led_slot_persistent_id(struct led_slot_list_entry *se)`

   Which returns the persistent slot ID or NULL on non-existence or error

The existing slot ID function is left untouched to avoid breaking code
that may rely on its value.

Rudimentary testing has been done on a single SES equipped hardware system.
SES leverages an enclosure ID for creating the SES persistent ID.

**TODO: investigate implementing persistent IDs for other transport layers
that expose the slots API.**
