### PR TITLE
SES: Correctly interpret element index field when EIIOE=1

### DIFF
--- a/src/lib/ses.c
+++ b/src/lib/ses.c
@@ -520,11 +520,11 @@ int ses_get_slots(struct ses_pages *sp, struct ses_slot **out_slots, int *out_sl
 
 				slots[j].index = ap[0] & 0x10 ? ap[3] : j;
 
-                                // If EIIOE=1, ELEMENT INDEX includes overall elements, otherwise not.
-                                // As (Array) Device Slot elements are always first in the list, there
-                                // will be exactly one overall element that needs to be ignored.
-                                if ((ap[0] & 0x10) && ((ap[2] & 0x3) == 0x01))
-                                  slots[j].index--;
+				// If EIIOE=1, ELEMENT INDEX includes overall elements, otherwise not.
+				// As (Array) Device Slot elements are always first in the list, there
+				// will be exactly one overall element that needs to be ignored.
+				if ((ap[0] & 0x10) && ((ap[2] & 0x3) == 0x01))
+					slots[j].index--;
 
 				get_led_status(sp, slots[j].index, &slots[j].ibpi_status);
 			}

--- a/src/lib/ses.c
+++ b/src/lib/ses.c
@@ -100,7 +100,7 @@ static void print_page10(struct ses_pages *sp)
 		printf("\tDescriptor len (x-1): %d\n", ai[1] + 1);
 		eip = ai[0] & 0x10;
 		if (eip)
-			printf("\tElement Index: %d\n", ai[3]);
+			printf("\tElement Index: %d EIIOE: %d\n", ai[3], (ai[2] & 0x3));
 		len = ai[1] + 2;
 		if ((ai[0] & 0xf) == SCSI_PROTOCOL_SAS) {
 			if (eip)
@@ -519,6 +519,13 @@ int ses_get_slots(struct ses_pages *sp, struct ses_slot **out_slots, int *out_sl
 					((uint64_t)addr_p[19]);
 
 				slots[j].index = ap[0] & 0x10 ? ap[3] : j;
+
+                                // If EIIOE=1, ELEMENT INDEX includes overall elements, otherwise not.
+                                // As (Array) Device Slot elements are always first in the list, there
+                                // will be exactly one overall element that needs to be ignored.
+                                if ((ap[0] & 0x10) && ((ap[2] & 0x3) == 0x01))
+                                  slots[j].index--;
+
 				get_led_status(sp, slots[j].index, &slots[j].ibpi_status);
 			}
 

--- a/src/lib/ses.c
+++ b/src/lib/ses.c
@@ -461,6 +461,7 @@ static void get_led_status(struct ses_pages *sp, int idx, enum led_ibpi_pattern 
 {
 	struct ses_slot_ctrl_elem *descriptors = (void *)(sp->page2.buf + 8);
 	struct ses_slot_ctrl_elem *desc_element = NULL;
+	element_type ele_type = sp->page1_types[0].element_type;
 	descriptors++;
 	desc_element = &descriptors[idx];
 
@@ -472,6 +473,43 @@ static void get_led_status(struct ses_pages *sp, int idx, enum led_ibpi_pattern 
 		*led_status = LED_IBPI_PATTERN_LOCATE;
 	else if (desc_element->b3 & 0x60)
 		*led_status = LED_IBPI_PATTERN_FAILED_DRIVE;
+	else if (desc_element->common_control & 0x40)
+		*led_status = LED_IBPI_PATTERN_PFA;
+
+	// Byte 1 is only valid for Array Device Slot elements
+	if ((*led_status == LED_IBPI_PATTERN_NORMAL) && (ele_type == SES_ARRAY_DEVICE_SLOT))
+	{
+		if (desc_element->array_slot_control & 0x04)
+			*led_status = LED_IBPI_PATTERN_FAILED_ARRAY;
+		else if (desc_element->array_slot_control & 0x02)
+			*led_status = LED_IBPI_PATTERN_REBUILD;
+		else if (desc_element->array_slot_control & 0x20)
+			*led_status = LED_IBPI_PATTERN_HOTSPARE;
+		else if (desc_element->array_slot_control & 0x08)
+			*led_status = LED_IBPI_PATTERN_DEGRADED;
+		else if (desc_element->array_slot_control & 0x10)
+			*led_status = LED_SES_REQ_CONS_CHECK;
+		else if (desc_element->array_slot_control & 0x01)
+			*led_status = LED_SES_REQ_ABORT;
+		else if (desc_element->array_slot_control & 0x40)
+			*led_status = LED_SES_REQ_RSVD_DEV;
+	}
+
+	if (*led_status == LED_IBPI_PATTERN_NORMAL)
+	{
+		if (desc_element->b2 & 0x40)
+			*led_status = LED_SES_REQ_DNR;
+		else if (desc_element->b2 & 0x08)
+			*led_status = LED_SES_REQ_INS;
+		else if (desc_element->b2 & 0x04)
+			*led_status = LED_SES_REQ_RM;
+		else if (desc_element->b3 & 0x10)
+			*led_status = LED_SES_REQ_DEV_OFF;
+		else if (desc_element->b3 & 0x08)
+			*led_status = LED_SES_REQ_EN_BA;
+		else if (desc_element->b3 & 0x04)
+			*led_status = LED_SES_REQ_EN_BB;
+	}
 }
 
 int ses_get_slots(struct ses_pages *sp, struct ses_slot **out_slots, int *out_slots_count)


### PR DESCRIPTION
Issue:
If an SES enclosure reports elements using EIIOE=1 (defined in SES-3), the mapping of SAS devices to slots is offset by 1, causing the incorrect LEDs to be changed.

Cause:
When parsing Additional Element Status descriptors, ledmon does not correctly interpret the SES ELEMENT INDEX field when EIIOE=1; it assumes the SES-2 interpretation where ELEMENT INDEX does not include overall elements. The EIIOE field is defined in SES-3, where an EIIOE=1 indicates that the ELEMENT INDEX field includes overall elements.

Solution:
As the (Array) Device Slot elements are required to be first in the list, there will be exactly one overall element prior to the individual (Array) Device Slot elements, so subtracting one from ELEMENT_INDEX if EIIOE=1 produces the same 0-based individual element index as assumed elsewhere.