### PR TITLE
SES: Correctly interpret element index field when EIIOE=1

### DIFF
--- a/src/lib/ses.c
+++ b/src/lib/ses.c
@@ -565,6 +565,18 @@ int ses_get_slots(struct ses_pages *sp, struct ses_slot **out_slots, int *out_sl
 					((uint64_t)addr_p[19]);
 
 				slots[j].index = ap[0] & 0x10 ? ap[3] : j;
+
+				/*
+				 * ses_slot.index excludes overall elements.
+				 * If EIIOE=1, ELEMENT INDEX includes overall
+				 * elements. For all other values of EIIOE,
+				 * ELEMENT INDEX excludes overall elements.
+				 * There will be one overall element per
+				 * element type (including the current one).
+				 */
+				if ((ap[0] & 0x10) && ((ap[2] & 0x3) == 0x01))
+					slots[j].index -= (i+1);
+
 				get_led_status(sp, t->element_type, slots[j].index,
 							   &slots[j].ibpi_status);
 			}


### PR DESCRIPTION
Issue:
If an SES enclosure reports elements using EIIOE=1 (defined in SES-3), the mapping of SAS devices to slots is offset by 1, causing the incorrect LEDs to be changed.

Cause:
When parsing Additional Element Status descriptors, ledmon does not correctly interpret the SES ELEMENT INDEX field when EIIOE=1; it assumes the SES-2 interpretation where ELEMENT INDEX does not include overall elements. The EIIOE field is defined in SES-3, where an EIIOE=1 indicates that the ELEMENT INDEX field includes overall elements.

Solution:
As the (Array) Device Slot elements are required to be first in the list, there will be exactly one overall element prior to the individual (Array) Device Slot elements, so subtracting one from ELEMENT_INDEX if EIIOE=1 produces the same 0-based individual element index as assumed elsewhere.